### PR TITLE
add cypress with automation test cases

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/cypress/e2e/issue_66_88.cy.ts
+++ b/cypress/e2e/issue_66_88.cy.ts
@@ -1,0 +1,82 @@
+import '@4tw/cypress-drag-drop'
+
+describe('Goal Input Automation', () => {
+    const doList = ["Do exercise", "Do shopping", "Do swimming"];
+    
+    before(() => {
+      cy.visit("http://localhost:5173/mm-local-editor/");
+      cy.contains("button", "Create Model").click();
+    });
+  
+    function clickGoalList(iconAlt: string): void {
+      cy.scrollTo('top');
+      cy.get(`img[alt="${iconAlt}"]`)
+        .should('exist')
+        .scrollIntoView()
+        .should("be.visible")
+        .parent() // get the <a> or clickable container
+        .click({ force: true });
+    }
+  
+  
+    function enterGoals(goals: string[], startIndex: number = 0): void {
+      goals.forEach((goal, index) => {
+        const actualIndex = startIndex + index;
+        cy.get("div.input-group input.form-control")
+          .eq(actualIndex)
+          .should("be.visible")
+          .click()
+          .clear()
+          .type(goal)
+          .should("have.value", goal)
+          .type("{enter}{enter}");
+        cy.wait(500);
+      });
+      
+    }
+
+    function addGoalsToHierarchy(tabName: string): void {
+        cy.scrollTo('top');
+        cy.get(`[id$="-tabpane-${tabName}"]`) // Matches any ID ending with -tabpane-Do
+        .find('th[style="width: 1px; white-space: nowrap;"] input.form-check-input')
+        .should('be.visible')
+        .click();
+
+        cy.contains("button", "Add Group").click();
+        cy.wait(500);
+    }
+
+    function dragGoalToHierarchy(): void {
+        cy.get('input.form-control[draggable="true"][type="text"]:not(.text-muted)')
+        .filter(':visible')
+        .eq(0) // gets the 1st element (0-based index)
+        .drag('#root > div:nth-child(1) > div > div:nth-child(3) > div:nth-child(2)');
+    }
+
+    // Bug: not allow duplicate goals to be placed in the Hierarchy
+    // Issue #88, #66: https://github.com/MotivationalModelling/mm-local-editor/issues/88
+    it("drag an existing goal to the hierarchy", () => {
+      // Click on the Do tab
+      clickGoalList("Do icon");
+      // Enter some different Do goals
+      enterGoals(doList, 0);
+      // Add all Do goals to the Hierarchy
+      addGoalsToHierarchy("Do");
+      // Drag the "Do excercise" goal to the Hierarchy
+      dragGoalToHierarchy();
+      // Search for all items in the Hierarchy having the text of "Do exercise"
+      // If it is correctly implemented, the number of items should be 2 
+      // (allowing duplicates in the Hierarchy as expected result)
+      cy.get('.nestable-item-name .tree-list div').then($divs => {
+        const divs = [...$divs];
+
+        // Get all indexes where text matches exactly "Do exercise"
+        const indexes = divs
+            .map((div, i) => div.textContent?.trim() === "Do exercise" ? i : -1)
+            .filter(i => i !== -1);
+
+        // Assert the count is exactly 2 (allowing a duplicate goal in the hierarchy)
+        expect(indexes.length).to.eq(2);
+      });
+    });
+  });

--- a/cypress/e2e/issue_87.cy.ts
+++ b/cypress/e2e/issue_87.cy.ts
@@ -1,0 +1,50 @@
+describe('Goal Input Automation', () => {
+    const feelList = ["Feel valued", "Feel valued", "Feel valued"];
+    
+    before(() => {
+      cy.visit("http://localhost:5173/mm-local-editor/");
+      cy.contains("button", "Create Model").click();
+    });
+  
+    function clickGoalList(iconAlt: string): void {
+      cy.scrollTo('top');
+      cy.get(`img[alt="${iconAlt}"]`)
+        .should('exist')
+        .scrollIntoView()
+        .should("be.visible")
+        .parent() // get the <a> or clickable container
+        .click({ force: true });
+    }
+  
+  
+    function enterGoals(goals: string[], startIndex: number = 0): void {
+      goals.forEach((goal, index) => {
+        const actualIndex = startIndex + index;
+        cy.get("div.input-group input.form-control")
+          .eq(actualIndex)
+          .should("be.visible")
+          .click()
+          .clear()
+          .type(goal)
+          .should("have.value", goal)
+          .type("{enter}{enter}");
+        cy.wait(500);
+      });
+      
+    }
+
+    // Bug: duplicate goals are still allowed in the same category of the Goal List
+    // Issue #87: https://github.com/MotivationalModelling/mm-local-editor/issues/87
+    it("add duplicate goals", () => {
+      // Click on the Feel tab
+      clickGoalList("Feel icon");
+      // Enter three Feel goals of the same value
+      enterGoals(feelList, 2);
+      // Check to ensure that there is only one Feel goal is added
+      // If the bug is fixed
+      cy.get('div.input-group input.form-control')
+      .filter((_, el) => (el as HTMLInputElement).value === 'Feel valued')
+      .should('have.length', 1);
+
+    });
+  });

--- a/cypress/e2e/issue_89.cy.ts
+++ b/cypress/e2e/issue_89.cy.ts
@@ -1,0 +1,78 @@
+describe('Goal Input Automation', () => {
+    const doList = ["Run SWEN90009", "Assess", "Teach", "Run workshops", "Two-way feedback", "Monitor progress"];
+    const beList = ["Clear", "Helpful", "Fair"];
+    const feelList = ["Good", "Confident", "Motivated"];
+    const concernList = ["Pressure"];
+    const whoList = ["Student", "Lecturer", "Supervisor"];
+  
+    const allGoals = [...doList, ...beList, ...feelList, ...concernList, ...whoList];
+    console.log('All goals:', allGoals);
+    
+    before(() => {
+      cy.visit("http://localhost:5173/mm-local-editor/");
+      cy.contains("button", "Create Model").click();
+    });
+  
+    function clickGoalList(iconAlt: string): void {
+      cy.scrollTo('top');
+      cy.get(`img[alt="${iconAlt}"]`)
+        .should('exist')
+        .scrollIntoView()
+        .should("be.visible")
+        .parent() // get the <a> or clickable container
+        .click({ force: true });
+    }
+  
+  
+    function enterGoals(goals: string[], startIndex: number = 0): void {
+      goals.forEach((goal, index) => {
+        const actualIndex = startIndex + index;
+        cy.get("div.input-group input.form-control")
+          .eq(actualIndex)
+          .should("be.visible")
+          .click()
+          .clear()
+          .type(goal)
+          .should("have.value", goal)
+          .type("{enter}{enter}");
+        cy.wait(1000);
+      });
+      
+    }
+
+    function addGoalsToHierarchy(tabName: string): void {
+        cy.scrollTo('top');
+        cy.get(`[id$="-tabpane-${tabName}"]`) // Matches any ID ending with -tabpane-Do
+        .find('th[style="width: 1px; white-space: nowrap;"] input.form-check-input')
+        .should('be.visible')
+        .click();
+
+        cy.contains("button", "Add Group").click();
+        cy.wait(500);
+    }
+
+    // Follow a scenario to create a model
+    // The selected scenario is based on Prof. Leon's lecture at https://youtu.be/4C_eHs5jy-Q
+    // And to reproduce the issue #89: https://github.com/MotivationalModelling/mm-local-editor/issues/89
+    it("adds all goals to respective lists", () => {
+      clickGoalList("Do icon");
+      enterGoals(doList, 0);
+      addGoalsToHierarchy("Do");
+    
+      clickGoalList("Be icon");
+      enterGoals(beList, doList.length + 1);
+      addGoalsToHierarchy("Be");
+    
+      clickGoalList("Feel icon");
+      enterGoals(feelList, doList.length + beList.length + 2);
+      addGoalsToHierarchy("Feel");
+    
+      clickGoalList("Concern icon");
+      enterGoals(concernList, doList.length + beList.length + feelList.length + 3);
+      addGoalsToHierarchy("Concern");
+    
+      clickGoalList("Who icon");
+      enterGoals(whoList, doList.length + beList.length + feelList.length + concernList.length + 4);
+      addGoalsToHierarchy("Who");
+    });
+  });

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,0 +1,37 @@
+/// <reference types="cypress" />
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@4tw/cypress-drag-drop": "^2.3.0",
     "@testing-library/react": "^16.2.0",
     "@types/d3": "^7.4.3",
     "@types/file-saver": "^2.0.7",
@@ -44,6 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4.2.1",
+    "cypress": "^14.5.2",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["cypress", "src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Hi everyone,

This is my change that supports automation tests with Cypress. It includes 3 scripts for issues #87, #88, and #89.

To run my scripts please follow the steps below

1. Run "npm install" to install new dependencies for Cypress
2. Run "npm run dev" to start the local server
3. Run "npx cypress open" to open Cypress
4. When Cypress is open, choose E2E (End-to-End Testing) mode and then choose the web browser (Chrome for example).
5. Choose the test case to run

Could you help me review the code and if there are any issues, please let me know.

Thanks,

Thi Thao Le
