### PR TITLE
fix(tree): add word wrapping and set min-width for each node

### DIFF
--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -31,6 +31,7 @@ const treeListStyle: React.CSSProperties = {
   borderRadius: "5px",
   alignItems: "center",
   padding: "0.1rem",
+  minWidth: "100px",
 };
 
 const treeInputStyle: React.CSSProperties = {
@@ -249,6 +250,8 @@ const Tree: React.FC<TreeProps> = ({
           style={{
             padding: ".5rem",
             flex: 1,
+            overflowWrap: "break-word",
+            wordBreak: "break-word",
           }}
         >
           {isEditing ? (


### PR DESCRIPTION
### What does this PR do?
- Fix tree node text overflow and improve layout
- Add automatic word wrapping and set minimum width for each tree node

### Changes
Updated Tree.tsx:
- Added minWidth to tree node container to prevent nodes from collapsing too small
- Added "break-word" to allow long text to wrap

### Screenshots
<img width="403" height="561" alt="image" src="https://github.com/user-attachments/assets/3ca33438-b9d0-409e-8bb7-e0f735c911fd" />

### Related issue
Closes Bug: Tree node text overflows container #110
