### PR TITLE
fix(header autofocus): fix the autofocus issue which causes unexpected…

### DIFF
--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -571,7 +571,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
       <Container>
         <Row className="row">
           <Col md={10}>
-            <div id={GRAPH_DIV_ID} ref={divGraph}/>
+            <div id={GRAPH_DIV_ID} ref={divGraph} tabIndex={0} style={{outline: 'none'}}/>
           </Col>
           <Col md={2}>
             <GraphSidebar graph={graph} recentreView={recentreView} />

--- a/src/components/header/ExportFileButton.tsx
+++ b/src/components/header/ExportFileButton.tsx
@@ -5,6 +5,7 @@ import { Dropdown, OverlayTrigger, Tooltip } from "react-bootstrap";
 import ErrorModal, { ErrorModalProps } from "../ErrorModal";
 import { useFileContext } from "../context/FileProvider";
 import { useGraph } from "../context/GraphContext";
+import { returnFocusToGraph } from "../utils/GraphUtils";
 
 // Add showGraphSection prop to control Export button enablement
 // This ensures Export is only available when user is in "Render Model" interface
@@ -127,6 +128,8 @@ const ExportFileButton = ({ showGraphSection }: { showGraphSection: boolean }) =
 		catch (error) {
 			console.error('Failed to save file: ', error);
 		}
+        // Return focus to graph container to enable keyboard shortcuts
+        returnFocusToGraph();
 	};
 
 	// Function to export graph as PNG
@@ -221,6 +224,9 @@ const ExportFileButton = ({ showGraphSection }: { showGraphSection: boolean }) =
 				}
 			}
 		}, 'image/png');
+
+        // Return focus to graph container to enable keyboard shortcuts
+        returnFocusToGraph();
 	};
 
 	// Check if the model is ready for export

--- a/src/components/header/SaveFileButton.tsx
+++ b/src/components/header/SaveFileButton.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button } from "react-bootstrap";
 import { JSONData, useFileContext } from "../context/FileProvider";
 import ErrorModal, { ErrorModalProps } from "../ErrorModal";
+import { returnFocusToGraph } from "../utils/GraphUtils";
 
 const SaveFileButton = () => {
 	const { setJsonFileHandle, treeData, tabData, goals } = useFileContext();
@@ -93,6 +94,7 @@ const SaveFileButton = () => {
 		} catch (error) {
 			console.error(`Error creating files: ${error}`);
 		}
+        returnFocusToGraph();
 	};
 	// className="m-2"
 

--- a/src/components/utils/GraphUtils.tsx
+++ b/src/components/utils/GraphUtils.tsx
@@ -5,3 +5,12 @@ export function getSymbolKeyByType(type: string): SymbolKey | undefined {
   return (Object.entries(SYMBOL_CONFIGS) as [SymbolKey, typeof SYMBOL_CONFIGS[SymbolKey]][])
     .find(([_, config]) => config.type === type)?.[0];
 }
+
+// Utility function to return focus to graph container
+// This enables keyboard shortcuts after save/export operations
+export const returnFocusToGraph = () => {
+    const graphContainer = document.getElementById('graphContainer');
+    if (graphContainer) {
+        graphContainer.focus();
+    }
+};


### PR DESCRIPTION
… focus to header buttons after export/save


1. Added a helper function in `GraphUtil.tsx` to follow the DRY principle.
2. Added `tabIndex` to the container to allow the container to receive focus from the keyboard.
3. Added `returnFocusToGraph` at the end of export/save trigger, making sure the focus will be backed to the graph after these events.