### PR TITLE
146 dragging goal to cluster creates duplicate copies and inherits previous children

### DIFF
--- a/src/components/GoalList.tsx
+++ b/src/components/GoalList.tsx
@@ -178,7 +178,7 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(
 			}
 		};
 		const handleDeleteRow = (row: TreeItem) => {
-			dispatch(deleteGoal(row));
+			dispatch(deleteGoal({item:row,deleteFromGoalList:true}));
 			const filteredGroupSelected = groupSelected.filter(
 				(item) => item.id !== row.id
 			);
@@ -259,7 +259,8 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(
 			// 	});
 			//
 			// 	setTabData(newTabData);
-				groupSelected.forEach((item: TreeItem) => dispatch(deleteGoal(item)));
+
+				groupSelected.forEach((item: TreeItem) => dispatch(deleteGoal({item:item,deleteFromGoalList:true})));
 				setGroupSelected([]); 
 			}
 		};

--- a/src/components/GoalList.tsx
+++ b/src/components/GoalList.tsx
@@ -12,7 +12,7 @@ import {TreeItem, useFileContext, newTreeItem, Label} from "./context/FileProvid
 import styles from "./TabButtons.module.css";
 import {BsFillTrash3Fill, BsPlus} from "react-icons/bs";
 import {isEmptyGoal,isGoalDraggable,isTextEmpty,handleGoalKeyPress,handleGoalBlur} from "./utils/GoalHint.tsx"
-import {addGoalToTab, deleteGoal, selectGoalsForLabel, updateTextForGoalId} from "./context/treeDataSlice.ts";
+import {addGoalToTab,deleteGoalFromGoalList, selectGoalsForLabel, updateTextForGoalId} from "./context/treeDataSlice.ts";
 
 const goalDescriptionForLabel = (label: Label): string => {
     const goalNames: Partial<Record<Label, string>> = {
@@ -178,7 +178,7 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(
 			}
 		};
 		const handleDeleteRow = (row: TreeItem) => {
-			dispatch(deleteGoal({item:row,deleteFromGoalList:true}));
+			dispatch(deleteGoalFromGoalList({item:row}));
 			const filteredGroupSelected = groupSelected.filter(
 				(item) => item.id !== row.id
 			);
@@ -260,7 +260,7 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(
 			//
 			// 	setTabData(newTabData);
 
-				groupSelected.forEach((item: TreeItem) => dispatch(deleteGoal({item:item,deleteFromGoalList:true})));
+				groupSelected.forEach((item: TreeItem) => dispatch(deleteGoalFromGoalList({item:item})));
 				setGroupSelected([]); 
 			}
 		};

--- a/src/components/Graphs/GraphHelpers.tsx
+++ b/src/components/Graphs/GraphHelpers.tsx
@@ -214,6 +214,7 @@ export const renderFunction = (
         height,
         style
     );
+    console.log("goalId:", goal.GoalID, " nodeId:", node.getId(), " value:", node.value);
     if (source) {
         graph.insertEdge(null, null, "", source, node);
     }

--- a/src/components/SectionPanel.tsx
+++ b/src/components/SectionPanel.tsx
@@ -155,6 +155,7 @@ const SectionPanel: React.FC<SectionPanelProps> = ({
       if (draggedItem && draggedItem.content) {
         // the first hierachy does not contain the dragged item
           if (!tree.map((index)=>(index.goalId)).includes(draggedItem.id)) {
+            console.log("dragged item: ",draggedItem)
               dispatch(addGoalToTree(draggedItem));
           } else {
               setExistingItemIds([...existingItemIds, draggedItem.id]);

--- a/src/components/SectionPanel.tsx
+++ b/src/components/SectionPanel.tsx
@@ -62,6 +62,7 @@ const SectionPanel: React.FC<SectionPanelProps> = ({
   const [groupSelected, setGroupSelected] = useState<TreeItem[]>([]);
 
   const [existingItemIds, setExistingItemIds] = useState<number[]>([]);
+  const [existingGoalReferenceInstanceId,setExistingGoalReferenceInstanceId]=useState<{ goalId: TreeItem["id"]; instanceID: TreeItem["instanceID"] }[]>([])
   const [existingError, setExistingError] = useState<boolean>(false);
 
   // const [isHintVisible, setIsHintVisible] = useState(true);
@@ -171,7 +172,10 @@ const SectionPanel: React.FC<SectionPanelProps> = ({
     
     // Filter groupSelected to get only objects whose IDs are not in treeData
     const newItemsToAdd = groupSelected.filter(
-      (item) => !treeIds.includes(item.id)
+      // current hierachy
+      (item) => !tree.some(
+        ref => ref.goalId === item.id
+        )
     );
 
     // If all items are in the tree, then show the warning
@@ -295,10 +299,13 @@ const SectionPanel: React.FC<SectionPanelProps> = ({
         ref={sectionTwoRef}
       >
         <Tree
-          existingItemIds={existingItemIds}
+
+          // existingItemIds={existingItemIds}
           // setTreeIds={setTreeIds}
           handleSynTableTree={handleSynTableTree}
-          setExistingItemIds={setExistingItemIds}
+          // setExistingItemIds={setExistingItemIds}
+          existingGoalReferenceInstanceId={existingGoalReferenceInstanceId}
+          setExistingGoalReferenceInstanceId={setExistingGoalReferenceInstanceId}
         />
       </div>
 

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -264,6 +264,7 @@ const Tree: React.FC<TreeProps> = ({
             ? "#FF474C"
             : "white",
         }}
+        key={`${treeItem.id}-${treeItem.instanceID}`}
         className="tree-list"
         onDoubleClick={handleDoubleClick}
       >

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -144,7 +144,7 @@ const Tree: React.FC<TreeProps> = ({
   //   return ids;
   // };
 
-  const getAllGoalInstances = (item: TreeItem): { goalId: number; instanceID: number }[] => {
+  const getAllGoalInstances = (item: TreeItem): { goalId: TreeItem["id"]; instanceID: TreeItem["instanceID"] }[] => {
     const result = [{ goalId: item.id, instanceID: item.instanceID }];
 
     if (item.children) {
@@ -360,6 +360,7 @@ const Tree: React.FC<TreeProps> = ({
         onChange={({ items }) => dispatch(setTreeData(items as TreeItem[]))}
         items={treeData}
         renderItem={renderItem}
+        idProp="instanceID"
         renderCollapseIcon={({ isCollapsed }) => (
           <Collapser isCollapsed={isCollapsed} />
         )}

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -97,7 +97,7 @@ const Tree: React.FC<TreeProps> = ({
   // Delete item by its id
   const deleteItem = () => {
     if (deletingItemRef?.current) {
-      dispatch(deleteGoal(deletingItemRef.current));
+      dispatch(deleteGoal({item:deletingItemRef.current,deleteFromGoalList:false}));
     }
     setShowDeleteWarning(false);
   };

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -20,7 +20,7 @@ import {
 } from "../components/utils/GoalHint.tsx"
 
 import "./Tree.css";
-import {deleteGoal, setTreeData} from "./context/treeDataSlice.ts";
+import {deleteGoalReferenceFromHierarchy, setTreeData} from "./context/treeDataSlice.ts";
 
 // Inline style for element in Nestable, css style import not working
 const treeListStyle: React.CSSProperties = {
@@ -97,7 +97,7 @@ const Tree: React.FC<TreeProps> = ({
   // Delete item by its id
   const deleteItem = () => {
     if (deletingItemRef?.current) {
-      dispatch(deleteGoal({item:deletingItemRef.current,deleteFromGoalList:false}));
+      dispatch(deleteGoalReferenceFromHierarchy({item:deletingItemRef.current}));
     }
     setShowDeleteWarning(false);
   };

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -264,7 +264,6 @@ const Tree: React.FC<TreeProps> = ({
             ? "#FF474C"
             : "white",
         }}
-        key={`${treeItem.id}-${treeItem.instanceID}`}
         className="tree-list"
         onDoubleClick={handleDoubleClick}
       >

--- a/src/components/context/FileProvider.tsx
+++ b/src/components/context/FileProvider.tsx
@@ -32,7 +32,7 @@ export const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeIte
     return{
         id: id,
         content: "",
-        instanceID:instanceID,  // give 0 when it is empty
+        instanceID:instanceID, 
         ...initFields
     }
 };
@@ -235,18 +235,7 @@ const FileProvider: React.FC<PropsWithChildren> = ({ children }) => {
     useEffect(() => {
         // Convert TreeNode[] to TreeItem[] for storage
         // Here we map TreeNode.goalId to TreeItem from state.goals
-        const treeItems:TreeItem[] = state.tree.map((treeNode:TreeNode) => {
-            const goal = state.goals[treeNode.goalId];
-            if (!goal) return;
-            return {
-                ...goal,
-                instanceID: treeNode.instanceID, 
-                children: treeNode.children?.map(child => ({
-                    ...state.goals[child.goalId],
-                    instanceID: child.instanceID,
-                }))
-            };
-        }).filter(Boolean) as TreeItem[];
+        const treeItems: TreeItem[] =  createTreeDataFromTreeNode(state.goals,state.tree)
 
         setTreeData(treeItems);
 

--- a/src/components/context/FileProvider.tsx
+++ b/src/components/context/FileProvider.tsx
@@ -26,12 +26,16 @@ export interface TreeNode {
 
 // require id and type fields, others optional.
 // create a empty treeItem
-export const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => ({
-    id: initFields.id ?? Date.now(),
-    content: "",
-    instanceID:initFields.instanceID??0,  // give 0 when it is empty
-    ...initFields
-});
+export const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => {
+    const id = initFields.id ?? Date.now();
+    const instanceID = initFields.instanceID ?? `${id}-${0}`;
+    return{
+        id: id,
+        content: "",
+        instanceID:instanceID,  // give 0 when it is empty
+        ...initFields
+    }
+};
 
 // Type of the json data
 export type JSONData = {
@@ -44,7 +48,7 @@ export type TreeItem = {
     id: number;
     content: string;
     type: Label;
-    instanceID:number;
+    instanceID:string;
     children?: TreeItem[];
 };
 
@@ -231,9 +235,9 @@ const FileProvider: React.FC<PropsWithChildren> = ({ children }) => {
     useEffect(() => {
         // Convert TreeNode[] to TreeItem[] for storage
         // Here we map TreeNode.goalId to TreeItem from state.goals
-        const treeItems = state.tree.map((treeNode:TreeNode) => {
+        const treeItems:TreeItem[] = state.tree.map((treeNode:TreeNode) => {
             const goal = state.goals[treeNode.goalId];
-            if (!goal) return null;
+            if (!goal) return;
             return {
                 ...goal,
                 instanceID: treeNode.instanceID, 
@@ -242,7 +246,7 @@ const FileProvider: React.FC<PropsWithChildren> = ({ children }) => {
                     instanceID: child.instanceID,
                 }))
             };
-        }).filter(Boolean);
+        }).filter(Boolean) as TreeItem[];
 
         setTreeData(treeItems);
 

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -25,20 +25,11 @@ export const createTreeFromTreeData = (
   treeData: TreeItem[],
   existingOcurrance: Record<TreeItem["id"], number> = {}
 ): TreeNode[] => {
-  
-  const existingDictionary = (goalId: TreeItem["id"]): number => {
-    if (existingOcurrance[goalId]===undefined) {
-      existingOcurrance[goalId] = 1;
-    } else {
-      existingOcurrance[goalId] = existingOcurrance[goalId] + 1;
-    }
-    return existingOcurrance[goalId];
-  };
 
   return treeData.map((ti) => ({
     goalId: ti.id,
     // if ti.instanceID exists, use it, else compute one
-    instanceID: existingDictionary(ti.id),
+    instanceID: ti.id,
     children: createTreeFromTreeData(ti.children ?? [], existingOcurrance)
   }));
 };

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -9,7 +9,6 @@ import {
     TreeNode
 } from "./FileProvider.tsx";
 import {InitialTab, initialTabs} from "../../data/initialTabs.ts";
-import { number } from "zod/v4";
 
 export const newTreeNode = ({goalId, instanceID,children = []}: {
     goalId: TreeItem["id"],
@@ -23,23 +22,13 @@ export const newTreeNode = ({goalId, instanceID,children = []}: {
 
 export const createTreeFromTreeData = (
   treeData: TreeItem[],
-  existingOcurrance: Record<TreeItem["id"], number> = {}
 ): TreeNode[] => {
-  
-  const existingDictionary = (goalId: TreeItem["id"]): number => {
-    if (existingOcurrance[goalId]===undefined) {
-      existingOcurrance[goalId] = 1;
-    } else {
-      existingOcurrance[goalId] = existingOcurrance[goalId] + 1;
-    }
-    return existingOcurrance[goalId];
-  };
 
   return treeData.map((ti) => ({
     goalId: ti.id,
     // if ti.instanceID exists, use it, else compute one
-    instanceID: existingDictionary(ti.id),
-    children: createTreeFromTreeData(ti.children ?? [], existingOcurrance)
+    instanceID: ti.instanceID,
+    children: createTreeFromTreeData(ti.children ?? [])
   }));
 };
 
@@ -146,11 +135,19 @@ const generateInstanceID = (treeIds:Record<TreeItem["id"], TreeItem["instanceID"
   if(treeIds[goalId]==undefined){
     treeIds[goalId]=[]
   }
+
   // give it new instance id 
-  const instanceId: TreeItem["instanceID"] = (treeIds[goalId].length > 0)
-    ? Math.max(...treeIds[goalId]) + 1
-    : 1;
-  return instanceId
+  const maxSuffix:number = treeIds[goalId].length > 0
+    ? Math.max(
+        ...treeIds[goalId].map(it => {
+          console.log("generateInstanceID: ",it)
+          const parts = it.split("-");
+          return Number(parts[-1]); // extract the last number
+        })
+      )
+    : 0;
+    
+  return `${goalId}-${maxSuffix+1}`
 }
 
 //

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -195,12 +195,12 @@ export const treeDataSlice = createSlice({
         },
         addGoalToTree: (state, action: PayloadAction<TreeItem>) => {
             // the instance id is given only when add to the tree
-      
+            const instanceID = generateInstanceID(state.treeIds,action.payload.id)
             state.tree.push(newTreeNode({
                 goalId: action.payload.id,
-                instanceID: generateInstanceID(state.treeIds,action.payload.id)
+                instanceID: instanceID
             }));
-
+            state.treeIds[action.payload.id].push(instanceID)
         },
         // remove goal(s) and its children from canvas
         removeGoalIdFromTree: (state, action: PayloadAction<{

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -228,7 +228,6 @@ export const treeDataSlice = createSlice({
             item:TreeItem}>) => {
             // only itself
             state.tree = removeAllReferenceFromHierarchy(state.tree,action.payload.item.id,action.payload.item.instanceID)
-            console.log("deleteGoal: ",action.payload.item.id)
             state.treeIds[action.payload.item.id] = state.treeIds[action.payload.item.id].filter(node=>node!==action.payload.item.instanceID);
         },
         

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -10,19 +10,36 @@ import {
 } from "./FileProvider.tsx";
 import {InitialTab, initialTabs} from "../../data/initialTabs.ts";
 
-export const newTreeNode = ({goalId, children = []}: {
+export const newTreeNode = ({goalId, copies,children = []}: {
     goalId: TreeItem["id"],
+    copies:TreeItem["copies"]
     children?: TreeNode[]
 }) => ({
     goalId,
+    copies,
     children
 });
 
-export const createTreeFromTreeData = (treeData: TreeItem[]): TreeNode[] => {
-    return treeData.map((ti) => ({
-        goalId: ti.id,
-        children: createTreeFromTreeData(ti.children ?? [])
-    }));
+export const createTreeFromTreeData = (
+  treeData: TreeItem[],
+  existingOcurrance: Record<TreeItem["id"], number> = {}
+): TreeNode[] => {
+  
+  const existingDictionary = (goalId: TreeItem["id"]): number => {
+    if (existingOcurrance[goalId]===undefined) {
+      existingOcurrance[goalId] = 1;
+    } else {
+      existingOcurrance[goalId] = existingOcurrance[goalId] + 1;
+    }
+    return existingOcurrance[goalId];
+  };
+
+  return treeData.map((ti) => ({
+    goalId: ti.id,
+    // if ti.copies exists, use it, else compute one
+    copies: existingDictionary(ti.id),
+    children: createTreeFromTreeData(ti.children ?? [], existingOcurrance)
+  }));
 };
 
 export const createTabContentFromInitialTab = ({label, icon, rows}: InitialTab): TabContent => ({
@@ -42,18 +59,17 @@ const createGoalsAndTabsFromTabContent = (initialTabs: InitialTab[]): {
     return {goals, tabs};
 };
 
-// return the reduced Treenode
+// remove each item from tree
 export const removeItemIdFromTree = (
   items: TreeNode[],
   id: TreeNode["goalId"],
+  copies:TreeNode["copies"],
   removeChildren: boolean=true
 ): TreeNode[] => {
   return items.reduce((acc, item) => {
 
-    console.log("removeCellRecursively: item.goalID ",item.goalId)
-    console.log("removeCellRecursively: id ",id)
-    if (item.goalId === id) {
-        console.log("removeCellRecursively: item ",item)
+    if (item.goalId === id && item.copies==copies) {
+       
       if (!removeChildren && item.children) {
         // Promote children to parent level
         acc.push(...item.children);
@@ -62,11 +78,33 @@ export const removeItemIdFromTree = (
     }
 
     if (item.children) {
-      item.children = removeItemIdFromTree(item.children, id, removeChildren);
+      item.children = removeItemIdFromTree(item.children, id, copies,removeChildren);
     }
     
     acc.push(item);
-    console.log("removeCellRecursively: acc ",acc)
+    return acc;
+  }, [] as TreeNode[]);
+};
+export const removeGoalFromGoalList = (
+  items: TreeNode[],
+  id: TreeNode["goalId"],
+): TreeNode[] => {
+  return items.reduce((acc, item) => {
+
+    if (item.goalId === id) {
+       
+      if (item.children) {
+        // Promote children to parent level
+        acc.push(...item.children);
+      }
+      return acc; // skip this item
+    }
+
+    if (item.children) {
+      item.children = removeGoalFromGoalList(item.children, id);
+    }
+    
+    acc.push(item);
     return acc;
   }, [] as TreeNode[]);
 };
@@ -78,9 +116,10 @@ export const removeItemIdFromTabs = (tabs: TabContent[], id: TreeItem["id"]): Ta
     }));
 };
 
+//
 export const createInitialState = (tabData: InitialTab[] = initialTabs, treeData: TreeItem[] = []) => {
-    console.log("tabData: ",tabData)
-    console.log("treeData: ",treeData)
+    console.log("initial tabData from localstorage: ",tabData)
+    console.log("initial treeData from localstorage: ",treeData)
     const {goals, tabs} = createGoalsAndTabsFromTabContent(tabData);
 
     // console.log("createInitialState", tabContent, goals, tabs);
@@ -98,7 +137,7 @@ export const treeDataSlice = createSlice({
         tree: [] as TreeNode[],
         tabs: {} as Map<Label, TabContent>,
         goals: {} as Record<TreeItem["id"], TreeItem>,
-        treeIds: [] as TreeItem["id"][]
+        treeIds: {} as Record<TreeItem["id"], TreeItem["copies"][]> 
     },
     reducers: {
         // setTreeData: (state, action: PayloadAction<TreeItem[]>) => {
@@ -119,26 +158,53 @@ export const treeDataSlice = createSlice({
             state.tree = createTreeFromTreeData(action.payload);
         },
         addGoalToTree: (state, action: PayloadAction<TreeItem>) => {
-            state.tree.push(newTreeNode({goalId: action.payload.id}));
-            state.treeIds.push(action.payload.id);
+            // copies incremented by 1
+            state.tree.push(newTreeNode({
+                goalId: action.payload.id,
+                copies: action.payload.copies + 1 
+            }));
+            if (!state.treeIds[action.payload.id]) {
+                state.treeIds[action.payload.id] = [];
+            }
+            console.log("addGoalToTree: ",action.payload.id)
+            console.log("addGoalToTree: ",action.payload.copies)
+            // Push the copiedId (instance ID)
+            state.treeIds[action.payload.id].push(action.payload.copies + 1 )
+            
+            // state.treeIds.push(action.payload.id);
         },
-        // remove goal(s) and its children from hierachy
+        // remove goal(s) and its children from canvas
         removeGoalIdFromTree: (state, action: PayloadAction<{
             id: TreeItem["id"],
+            copies:TreeItem["copies"]
             removeChildren: boolean
         }>) => {
-            state.tree = removeItemIdFromTree(state.tree, action.payload.id, action.payload.removeChildren);
+            state.tree = removeItemIdFromTree(state.tree, action.payload.id,action.payload.copies, action.payload.removeChildren);
             state.treeIds = createTreeIdsFromTreeNode(state.tree);
         },
-        deleteGoal: (state, action: PayloadAction<TreeItem>) => {
-            const tabContent = state.tabs.get(action.payload.type);
+        // delete from goal list/hierachy
+        deleteGoal: (state, action: PayloadAction<{
+            item:TreeItem,
+            deleteFromGoalList:boolean}>) => {
+            console.log("delete single goal: ",action.payload.deleteFromGoalList)
+
+            const tabContent = state.tabs.get(action.payload.item.type);
             if (tabContent) {
-                tabContent.goalIds = tabContent.goalIds.filter((id) => id !== action.payload.id);
+                tabContent.goalIds = tabContent.goalIds.filter((id) => id !== action.payload.item.id);
             }
-            // reassign the value
-            state.tree = removeItemIdFromTree(state.tree, action.payload.id);
-            state.treeIds = state.treeIds.filter((treeId) => treeId !== action.payload.id);
-            delete state.goals[action.payload.id];
+            // deleteFromGoalList
+            if(action.payload.deleteFromGoalList){
+                delete state.goals[action.payload.item.id];
+                delete state.treeIds[action.payload.item.id];
+            }else{
+                // not deleteFromGoalList -> hierachy
+                state.tree = removeGoalFromGoalList(state.tree, action.payload.item.id);
+                if (state.treeIds[action.payload.item.id]) {
+                    state.treeIds[action.payload.item.id] = state.treeIds[action.payload.item.id].filter(
+                    copiedId => copiedId !== action.payload.item.copies
+                    );
+            }}
+            
         },
         updateTextForGoalId: (state, action: PayloadAction<{
             id: TreeItem["id"],

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -129,23 +129,25 @@ const removeAllReferenceFromHierarchy = (
     }));
 };
 
-
-const generateInstanceID = (treeIds:Record<TreeItem["id"], TreeItem["instanceID"][]>,goalId:TreeItem["id"]):TreeItem["instanceID"]=>{
-  //if the goal is the first time moved to the hierachy
-  if(treeIds[goalId]==undefined){
-    treeIds[goalId]=[]
-  }
-
-  // give it new instance id 
-  const maxSuffix:number = treeIds[goalId].length > 0
+const generateMaxSuffix  = (treeIds:Record<TreeItem["id"], TreeItem["instanceID"][]>,goalId:TreeItem["id"]):number=>{
+  return treeIds[goalId].length > 0
     ? Math.max(
         ...treeIds[goalId].map(it => {
-          console.log("generateInstanceID: ",it)
           const parts = it.split("-");
           return Number(parts[-1]); // extract the last number
         })
       )
     : 0;
+}
+
+const generateInstanceID = (treeIds:Record<TreeItem["id"], TreeItem["instanceID"][]>,goalId:TreeItem["id"]):TreeItem["instanceID"]=>{
+  //if the goal is the first time moved to the hierachy
+  if(treeIds[goalId]== undefined){
+    treeIds[goalId]=[]
+  }
+
+  // give it new instance id 
+  const maxSuffix:number = generateMaxSuffix(treeIds,goalId)
     
   return `${goalId}-${maxSuffix+1}`
 }

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -25,11 +25,20 @@ export const createTreeFromTreeData = (
   treeData: TreeItem[],
   existingOcurrance: Record<TreeItem["id"], number> = {}
 ): TreeNode[] => {
+  
+  const existingDictionary = (goalId: TreeItem["id"]): number => {
+    if (existingOcurrance[goalId]===undefined) {
+      existingOcurrance[goalId] = 1;
+    } else {
+      existingOcurrance[goalId] = existingOcurrance[goalId] + 1;
+    }
+    return existingOcurrance[goalId];
+  };
 
   return treeData.map((ti) => ({
     goalId: ti.id,
     // if ti.instanceID exists, use it, else compute one
-    instanceID: ti.id,
+    instanceID: existingDictionary(ti.id),
     children: createTreeFromTreeData(ti.children ?? [], existingOcurrance)
   }));
 };

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -4,7 +4,7 @@ export type GoalType = "Functional" | "Quality" | "Stakeholder" | "Negative" | "
 
 export interface GoalBase {
     GoalID: number
-    Copies:number
+    InstanceID:number
     GoalType: GoalType
     GoalContent: string
     GoalNote: string
@@ -50,7 +50,7 @@ export const GoalTypeSchema = z.enum(
 
 export const GoalBaseSchema = z.object({
     GoalID: z.number(),
-    Copies:z.number(),
+    InstanceID:z.number(),
     GoalType: GoalTypeSchema,
     GoalContent: z.string(),
     GoalNote: z.string()

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -4,7 +4,7 @@ export type GoalType = "Functional" | "Quality" | "Stakeholder" | "Negative" | "
 
 export interface GoalBase {
     GoalID: number
-    InstanceID:number
+    InstanceID:string
     GoalType: GoalType
     GoalContent: string
     GoalNote: string

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -4,6 +4,7 @@ export type GoalType = "Functional" | "Quality" | "Stakeholder" | "Negative" | "
 
 export interface GoalBase {
     GoalID: number
+    Copies:number
     GoalType: GoalType
     GoalContent: string
     GoalNote: string
@@ -49,6 +50,7 @@ export const GoalTypeSchema = z.enum(
 
 export const GoalBaseSchema = z.object({
     GoalID: z.number(),
+    Copies:z.number(),
     GoalType: GoalTypeSchema,
     GoalContent: z.string(),
     GoalNote: z.string()

--- a/src/data/initialTabs.ts
+++ b/src/data/initialTabs.ts
@@ -1,4 +1,4 @@
-import { Label, TreeItem } from "../components/context/FileProvider.tsx";
+import { Label, TreeItem,newTreeItem  } from "../components/context/FileProvider.tsx";
 
 import BeIcon from "/img/Cloud.png";
 import DoIcon from "/img/Function.png";
@@ -12,17 +12,17 @@ export interface InitialTab {
     rows: TreeItem[]
 }
 
-//TODO: this is a duplicate copy of this function to avoid a circular import -- fix this!!
-const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => {
-    const id = initFields.id ?? Date.now();
-    const instanceID = initFields.instanceID ?? `${id}-${0}`;
-    return{
-        id: id,
-        content: "",
-        instanceID:instanceID,  // give 0 when it is empty
-        ...initFields
-    }
-};
+// //TODO: this is a duplicate copy of this function to avoid a circular import -- fix this!!
+// const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => {
+//     const id = initFields.id ?? Date.now();
+//     const instanceID = initFields.instanceID ?? `${id}-${0}`;
+//     return{
+//         id: id,
+//         content: "",
+//         instanceID:instanceID,  // give 0 when it is empty
+//         ...initFields
+//     }
+// };
 
 // Predefined constant cluster to use for the example graph
 export const defaultTreeData: TreeItem[] = [{

--- a/src/data/initialTabs.ts
+++ b/src/data/initialTabs.ts
@@ -25,41 +25,49 @@ export const defaultTreeData: TreeItem[] = [{
     id: 1,
     content: "Do",
     type: "Do",
+    copies:1,
     children: [{
         id: 6,
         content: "Do1",
         type: "Do",
+        copies:1,
         children: [{
             id: 7,
             content: "Do2",
             type: "Do",
+            copies:1,
             children: []
         }]
     }, {
         id: 8,
         content: "Do3",
         type: "Do",
+        copies:1,
         children: []
     }]
 }, {
     id: 2,
     content: "Be",
     type: "Be",
+    copies:1,
     children: []
 }, {
     id: 3,
     content: "Feel",
     type: "Feel",
+    copies:1,
     children: []
 }, {
     id: 4,
     content: "Who",
     type: "Who",
+    copies:1,
     children: []
 }, {
     id: 5,
     content: "Concern",
     type: "Concern",
+    copies:1,
     children: []
 }];
 

--- a/src/data/initialTabs.ts
+++ b/src/data/initialTabs.ts
@@ -14,8 +14,9 @@ export interface InitialTab {
 
 // TODO: this is a duplicate copy of this function to avoid a circular import -- fix this!!
 const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => ({
-    content: "",
     id: initFields.id ?? Date.now(),
+    content: "",
+    copies:initFields.copies??1,
     ...initFields
 });
 

--- a/src/data/initialTabs.ts
+++ b/src/data/initialTabs.ts
@@ -12,62 +12,66 @@ export interface InitialTab {
     rows: TreeItem[]
 }
 
-// TODO: this is a duplicate copy of this function to avoid a circular import -- fix this!!
-const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => ({
-    id: initFields.id ?? Date.now(),
-    content: "",
-    instanceID:initFields.instanceID??1,
-    ...initFields
-});
+//TODO: this is a duplicate copy of this function to avoid a circular import -- fix this!!
+const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => {
+    const id = initFields.id ?? Date.now();
+    const instanceID = initFields.instanceID ?? `${id}-${0}`;
+    return{
+        id: id,
+        content: "",
+        instanceID:instanceID,  // give 0 when it is empty
+        ...initFields
+    }
+};
 
 // Predefined constant cluster to use for the example graph
 export const defaultTreeData: TreeItem[] = [{
     id: 1,
     content: "Do",
     type: "Do",
-    instanceID:1,
+    instanceID:"1-1",
     children: [{
         id: 6,
         content: "Do1",
         type: "Do",
-        instanceID:1,
+        instanceID:"6-1",
         children: [{
             id: 7,
             content: "Do2",
             type: "Do",
-            instanceID:1,
+            instanceID:"7-1",
             children: []
         }]
     }, {
         id: 8,
         content: "Do3",
         type: "Do",
-        instanceID:1,
+        instanceID:"8-1",
         children: []
     }]
 }, {
     id: 2,
     content: "Be",
     type: "Be",
-    instanceID:1,
+    instanceID:"2-1",
     children: []
 }, {
     id: 3,
     content: "Feel",
     type: "Feel",
-    instanceID:1,
+    instanceID:"3-1",
     children: []
 }, {
     id: 4,
     content: "Who",
     type: "Who",
-    instanceID:1,
+    instanceID:"4-1",
     children: []
 }, {
     id: 5,
     content: "Concern",
     type: "Concern",
-    instanceID:1,
+    instanceID:"5-1",
     children: []
 }];
 

--- a/src/data/initialTabs.ts
+++ b/src/data/initialTabs.ts
@@ -16,7 +16,7 @@ export interface InitialTab {
 const newTreeItem = (initFields: Pick<TreeItem, "type"> & Partial<TreeItem>): TreeItem => ({
     id: initFields.id ?? Date.now(),
     content: "",
-    copies:initFields.copies??1,
+    instanceID:initFields.instanceID??1,
     ...initFields
 });
 
@@ -25,49 +25,49 @@ export const defaultTreeData: TreeItem[] = [{
     id: 1,
     content: "Do",
     type: "Do",
-    copies:1,
+    instanceID:1,
     children: [{
         id: 6,
         content: "Do1",
         type: "Do",
-        copies:1,
+        instanceID:1,
         children: [{
             id: 7,
             content: "Do2",
             type: "Do",
-            copies:1,
+            instanceID:1,
             children: []
         }]
     }, {
         id: 8,
         content: "Do3",
         type: "Do",
-        copies:1,
+        instanceID:1,
         children: []
     }]
 }, {
     id: 2,
     content: "Be",
     type: "Be",
-    copies:1,
+    instanceID:1,
     children: []
 }, {
     id: 3,
     content: "Feel",
     type: "Feel",
-    copies:1,
+    instanceID:1,
     children: []
 }, {
     id: 4,
     content: "Who",
     type: "Who",
-    copies:1,
+    instanceID:1,
     children: []
 }, {
     id: 5,
     content: "Concern",
     type: "Concern",
-    copies:1,
+    instanceID:1,
     children: []
 }];
 


### PR DESCRIPTION
Description:

This PR addresses an issue where dragging treeitem with its children caused duplicated nodes.

Problem:

Each tree item in Nestable previously default used id as its primary key.

Since the same goal can be added multiple times to the tree (as long as it is not in the same hierarchy), the id alone is no longer unique.

This caused Nestable to clone nodes multiple times and triggered React warnings about non-unique keys.

Solution:

Introduce an extra property instanceID for each TreeItem. The format is "id-instanceID".

Use instanceID as the primary key for Nestable by setting the idProp="instanceID" on the Nestable component.

This ensures that each item in the tree has a unique key, preventing duplicate cloning while allowing multiple instances of the same goal.