### PR TITLE
fix(ui): adjust the ui so that it won't easily overlap

### DIFF
--- a/src/components/FileUploadSection.tsx
+++ b/src/components/FileUploadSection.tsx
@@ -13,7 +13,7 @@ const FileUploadSection = ({
 	onUpload,
 }: FileUploadSectionProps) => {
 	return (
-		<div className="mt-3 border border-primary-subtle rounded file-container p-4 align-content-center mx-5">
+		<div className="mt-3 border border-primary-subtle rounded file-container py-2 px-4 align-content-center mx-5">
 			{/* File remove button */}
 			<div
 				onClick={onRemove}

--- a/src/components/WelcomeButtons.tsx
+++ b/src/components/WelcomeButtons.tsx
@@ -212,7 +212,7 @@ const WelcomeButtons = ({ isDragging, setIsDragging }: WelcomeButtonsProps) => {
 					)}
 					<div
 						className="position-absolute d-flex flex-row gap-5"
-						style={{ bottom: "160px" }}
+						style={{ bottom: "80px" }}
 					>
 						<Button
 							variant="primary"


### PR DESCRIPTION
a small simple fix on the ui so that the file selection section won't overlap with the buttons anymore (in most cases). Doesn't work when the height is too small (< ~620px).

<img width="2024" height="1054" alt="image" src="https://github.com/user-attachments/assets/23d331c3-7939-4d82-befc-18b4416bf292" />
<img width="2212" height="1066" alt="image" src="https://github.com/user-attachments/assets/ab2d4c3e-ebcc-40bb-8db8-1441096171fe" />

closes #127