### PR TITLE
fix(progress bar): the tips will now pop up correctly

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -94,7 +94,9 @@ const ProgressBar = ({
                 <OverlayTrigger trigger="click"
                                 placement="right"
                                 overlay={clusterInfoPopover}>
-                    <BsInfoCircleFill className="ms-1"/>
+                    <span>
+                        <BsInfoCircleFill className="ms-1"/>
+                    </span>
                 </OverlayTrigger>
               </span>
           </div>
@@ -106,7 +108,9 @@ const ProgressBar = ({
               <OverlayTrigger trigger="click"
                               placement="left"
                               overlay={graphInfoPopover}>
-                  <BsInfoCircleFill className="ms-1"/>
+                  <span>
+                      <BsInfoCircleFill className="ms-1"/>
+                  </span>
               </OverlayTrigger>
               <ShowGoalSectionButton showGoalSection={showGoalSection}
                                      onClick={(ev) => {


### PR DESCRIPTION
<img width="1952" height="294" alt="image" src="https://github.com/user-attachments/assets/2fd60213-38d2-446c-a011-c160775e793f" />

closes #152 