### PR TITLE
#81 enhancement support enter to save edits and enable in place text editing in the canvas

### DIFF
--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -31,6 +31,7 @@ import WarningMessage from "./WarningMessage";
 import {VERTEX_FONT} from "../utils/GraphConstants.tsx"
 import {removeGoalIdFromTree} from "../context/treeDataSlice.ts";
 import ConfirmModal from "../ConfirmModal.tsx";
+import { fixEditorPosition } from "../utils/GraphUtils.tsx";
 
 // ---------------------------------------------------------------------------
 
@@ -532,6 +533,7 @@ const deleteItemFromGraph = (graph:Graph, removeChildrenFlag: boolean) => {
 
       setGraphStyle(graphInstance);
       graphListener(graphInstance);
+      fixEditorPosition(graphInstance);
       supportFunctions(graphInstance);
       registerCustomShapes();
       setGraph(graphInstance);

--- a/src/components/utils/GraphUtils.tsx
+++ b/src/components/utils/GraphUtils.tsx
@@ -1,4 +1,6 @@
+import { Graph, InternalEvent } from '@maxgraph/core';
 import { SYMBOL_CONFIGS, SymbolKey } from './GraphConstants';
+import { update } from 'idb-keyval';
 
 // Finds the symbol key (e.g. 'STAKEHOLDER') based on the type
 export function getSymbolKeyByType(type: string): SymbolKey | undefined {
@@ -13,4 +15,35 @@ export const returnFocusToGraph = () => {
     if (graphContainer) {
         graphContainer.focus();
     }
+};
+
+// Keep the in-place text editor at correct position 
+export function fixEditorPosition(graph: Graph) {
+    const container = graph.container as HTMLElement;
+    container.style.position = 'relative';
+    
+    // Apply the correct position to the text editor element
+    const updateEditor = (el: HTMLElement) => {
+        el.style.position = 'absolute';
+        el.style.transformOrigin = '0 0';
+        el.style.zIndex = '10';
+        if (el.parentElement !== container) {
+          container.appendChild(el);
+        }
+    };
+
+    const findEditorEl = (): HTMLElement | null => {
+        return (
+          container.querySelector('.mxCellEditor') ||
+          document.querySelector('.mxCellEditor')
+        ) as HTMLElement | null;
+    };
+
+    const adjustOnce = () => {
+        const el = findEditorEl();
+        if (el) updateEditor(el);
+    };
+
+    const observer = new MutationObserver(() => adjustOnce());
+    observer.observe(container, { childList: true, subtree: true });
 };

--- a/src/components/utils/GraphUtils.tsx
+++ b/src/components/utils/GraphUtils.tsx
@@ -30,6 +30,14 @@ export function fixEditorPosition(graph: Graph) {
         if (el.parentElement !== container) {
           container.appendChild(el);
         }
+
+        // Press "Enter" to save editing
+        el.addEventListener("keydown", (e: KeyboardEvent) => {
+            if (e.key === "Enter") {
+                e.preventDefault();     // prevent press Enter to start a newline
+                graph.stopEditing(false);
+            }
+        });
     };
 
     const findEditorEl = (): HTMLElement | null => {


### PR DESCRIPTION
Instead of modifying the original event listener from mxGraph, this update adds a separate function that detects when the `.mxCellEditor` element appears, then adjusts its position and save behavior.

**Implementation**
- Use a custom function with a `MutationObserver` to listen for the editor’s appearance.
- When `.mxCellEditor` is detected, fix its CSS position (absolute) and add `Enter=Save` behavior.
- No direct modification to mxGraph’s internal event listener or DOM creation process.

**Reason**
Because the original code directly uses mxGraph’s built-in event listener and internal editor creation logic, I cannot safely modify the editor’s CSS or key handling there. This approach provides the same result without touching mxGraph internals.