### PR TITLE
fix: correct the var name

### DIFF
--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -285,7 +285,7 @@ const deleteItemFromGraph = (graph:Graph, removeChildrenFlag: boolean) => {
                   });
               } else {
                   numericCellIds.forEach((instanceId, i) => {
-                    dispatch(updateTextForInstanceId({instanceId, text: newGoalValues[i]}));
+                      dispatch(updateTextForInstanceId({instanceId, text: newGoalValues[i]}));
                   });
               }
             }


### PR DESCRIPTION
@bggolding Ben I have changed the name 'newContent' to 'newGoalValues' in the last pr but I missed one instance. This PR updates the one I missed to use the new variable name 'newGoalValues'