### PR TITLE
Fix #164 Can't edit the goal name after dragging it from the toolbar

### DIFF
--- a/src/components/utils/GraphUtils.tsx
+++ b/src/components/utils/GraphUtils.tsx
@@ -14,17 +14,20 @@ export const getSymbolConfigByShape = (shape: string): SymbolConfig | undefined 
 
 /**
  * Extracts ID strings from a cell:
- * - Supports multiple comma-separated IDs like: "Functional-123-1,123-2,123-3"
- * - Returns an array of strings, e.g. ["123-1", "123-2", "123-3"]
+ * - Supports multiple comma-separated IDs like: "Nonfunctional-[5-1,1762312908316-1]"
+ * - Returns an array of strings, e.g. ["5-1", "1762312908316-1"]
  */
 export function getCellNumericIds(cell: Cell): string[] {
     const cellId = cell.getId();
     if (cellId) {
         const match = cellId.match(/^(Functional|Nonfunctional)-(.+)$/);
         if (match) {
-        return match[2]
-            .split(",")
-            .map(s => s.trim())
+            return match[2]
+                .split(",")
+                .map(s => s.replace(/[\[\]\s]/g, ""))
+                .filter(s => s.length > 0);
+        } else {
+            throw new Error(`badly formatted cellId "${cellId}"`);
         }
     }
     return [];
@@ -170,10 +173,9 @@ export function generateCellId<T extends keyof IdsForType>(type: T,ids: IdsForTy
 
 export const parseInstanceId = (instanceId: string) => {
     const bits = instanceId.split("-").map(s => s.trim());
-    // TODO：After finalize id generate logic, add formate check like below
-    // if (bits.length !== 2) {
-    //     throw new Error(`badly formatted instanceId "${instanceId}"`);
-    // }
+    if (bits.length !== 2) {
+        throw new Error(`badly formatted instanceId "${instanceId}"`);
+    }
     
     const [goalId, refId] = bits.map(Number);
 


### PR DESCRIPTION
### Description
The issue occurred because the ID parsing logic didn’t match the new ID generation format, causing edit actions to fail after dragging new goals.

### Changes
- Updated getCellNumericIds in src/components/utils/GraphUtils.tsx
- Updated parseInstanceId

### Result
Goals dragged from the toolbar can now be edited correctly.

related issue: #164 