### PR TITLE
solve Author identity unknown issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,3 +49,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
A ProcessError: **Author identity unknown occurs** during the automated Continuous Integration/Continuous Deployment (CI/CD) process, specifically when trying to push the latest changes to **GitHub Pages** after a branch is approved and merged into the **develop** branch.

So use a dedicated bot identity ensures the deployment process is decoupled from individual developer settings, making the automated workflow robust and preventing future author identity errors.