### PR TITLE
#254 - When adding a goal using drag and drop, the title isn't editable. 

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -135,7 +135,7 @@ export type TreeGoal = {
 export const newTreeGoal = (initFields: Pick<TreeGoal, "type"> & Partial<TreeGoal>): TreeGoal => {
     const id = initFields.id ?? Date.now();
     const instanceId = initFields.instanceId ?? `${id}-0`;
-    return {id, content: "", instanceId, ...initFields};
+    return { id, content: "New Goal", instanceId, ...initFields };
 };
 
 // Define the structure for the content of each tab


### PR DESCRIPTION
Fix would be to initialize dragged goals with a default title so they are editable immediately.

The goal starts with content: "", it is treated as an empty goal. In GoalHint.tsx, editing appears to be restricted when the goal content is empty (isEmptyGoal() / canEditGoal()), which likely prevents editing the title in the Arrange Hierarchy view.

In src/components/types.ts, the newTreeGoal() function initializes a goal with empty content:
```

export const newTreeGoal = (initFields: Pick<TreeGoal, "type"> & Partial<TreeGoal>): TreeGoal => {
    const id = initFields.id ?? Date.now();
    const instanceId = initFields.instanceId ?? `${id}-0`;
    return { id, content: "", instanceId, ...initFields };
};

```
Because the goal starts with content: "", it is treated as an empty goal. In GoalHint.tsx, editing appears to be restricted when the goal content is empty (isEmptyGoal() / canEditGoal()), which likely prevents editing the title in the Arrange Hierarchy view.

One possible fix would be to initialize dragged goals with a default title so they are editable immediately.

Change I made:
```

export const newTreeGoal = (initFields: Pick<TreeGoal, "type"> & Partial<TreeGoal>): TreeGoal => {
    const id = initFields.id ?? Date.now();
    const instanceId = initFields.instanceId ?? `${id}-0`;
    return { id, content: "New Goal", instanceId, ...initFields };
};
```