### PR TITLE
fix: make zoom button group responsive

### DIFF
--- a/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
+++ b/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
@@ -11,18 +11,21 @@ const ZoomButtons = ({recentreView}: ZoomButtonsProps) => {
     const {graph} = useGraph();
 
     return (
-        <ButtonGroup className="w-100" size="sm">
-            <Button variant="light"
+        <ButtonGroup className="w-100 d-flex flex-wrap" size="sm">
+            <Button className="flex-fill"
+                    variant="light"
                     size="sm"
                     onClick={() => graph?.zoomIn()}>
                 <BsZoomIn/>
             </Button>
-            <Button variant="light"
+            <Button className="flex-fill"
+                    variant="light"
                     size="sm"
                     onClick={() => recentreView()}>
                 <BsStopCircle/>
             </Button>
-            <Button variant="light"
+            <Button className="flex-fill"
+                    variant="light"
                     size="sm"
                     onClick={() => graph?.zoomOut()}>
                 <BsZoomOut/>

--- a/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
+++ b/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
@@ -25,7 +25,7 @@ const ZoomButtons = ({recentreView}: ZoomButtonsProps) => {
                 resizeObserver.disconnect();
             };
         }
-    }, [containerRef.current?.offsetWidth]);
+    }, []);
 
     return (
         <ButtonGroup ref={containerRef} 

--- a/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
+++ b/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
@@ -2,7 +2,7 @@ import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Button from "react-bootstrap/Button";
 import {BsStopCircle, BsZoomIn, BsZoomOut} from "react-icons/bs";
 import {useGraph} from "../../context/GraphContext.tsx";
-import { useEffect, useRef, useState } from "react";
+import {useEffect, useRef, useState} from "react";
 
 type ZoomButtonsProps = {
   recentreView: () => void
@@ -15,23 +15,21 @@ const ZoomButtons = ({recentreView}: ZoomButtonsProps) => {
     const [containerWidth, setContainerWidth] = useState(0);
   
     useEffect(() => {
-        const container = containerRef.current;
-
-        if (container) {
+        if (containerRef.current) {
             const resizeObserver = new ResizeObserver(() => {
-                setContainerWidth(container.offsetWidth);
+                setContainerWidth(containerRef.current!.offsetWidth);
             });
-            resizeObserver.observe(container);
+            resizeObserver.observe(containerRef.current);
 
             return () => {
                 resizeObserver.disconnect();
             };
         }
-    }, []);
+    }, [containerRef.current?.offsetWidth]);
 
     return (
         <ButtonGroup ref={containerRef} 
-                    className={`w-100 d-flex ${containerWidth < HORIZONTAL_THRESHOLD ? "flex-column" : "flex-row"}`} 
+                    className={`w-100 d-flex ${(containerWidth < HORIZONTAL_THRESHOLD) ? "flex-column" : "flex-row"}`} 
                     size="sm">
             <Button className="flex-fill"
                     variant="light"

--- a/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
+++ b/src/components/Graphs/SidebarComponents/ZoomButtons.tsx
@@ -2,6 +2,7 @@ import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Button from "react-bootstrap/Button";
 import {BsStopCircle, BsZoomIn, BsZoomOut} from "react-icons/bs";
 import {useGraph} from "../../context/GraphContext.tsx";
+import { useEffect, useRef, useState } from "react";
 
 type ZoomButtonsProps = {
   recentreView: () => void
@@ -9,9 +10,29 @@ type ZoomButtonsProps = {
 
 const ZoomButtons = ({recentreView}: ZoomButtonsProps) => {
     const {graph} = useGraph();
+    const HORIZONTAL_THRESHOLD = 90; 
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [containerWidth, setContainerWidth] = useState(0);
+  
+    useEffect(() => {
+        const container = containerRef.current;
+
+        if (container) {
+            const resizeObserver = new ResizeObserver(() => {
+                setContainerWidth(container.offsetWidth);
+            });
+            resizeObserver.observe(container);
+
+            return () => {
+                resizeObserver.disconnect();
+            };
+        }
+    }, []);
 
     return (
-        <ButtonGroup className="w-100 d-flex flex-wrap" size="sm">
+        <ButtonGroup ref={containerRef} 
+                    className={`w-100 d-flex ${containerWidth < HORIZONTAL_THRESHOLD ? "flex-column" : "flex-row"}`} 
+                    size="sm">
             <Button className="flex-fill"
                     variant="light"
                     size="sm"


### PR DESCRIPTION
# Description
#221
[git issue](https://github.com/MotivationalModelling/mm-local-editor/issues/221)
Make the zoom button group fill parent width and allow buttons to wrap when space is too small.

# Current 
https://github.com/user-attachments/assets/99b4b0c1-82e8-42cd-a15e-24877421b7c2

