### PR TITLE
243 items undesirably revert to previous position

### DIFF
--- a/src/components/Graphs/GraphHelpers.tsx
+++ b/src/components/Graphs/GraphHelpers.tsx
@@ -2,6 +2,7 @@ import {
     Graph,
     Rectangle,
     Cell,
+    Geometry,
 } from "@maxgraph/core";
 import {ClusterGoal, GlobObject, InstanceId} from "../types.ts";
 import {GoalModelLayout} from "./GoalModelLayout";
@@ -595,6 +596,36 @@ export const renderLegend = (graph: Graph): Cell => {
     });
 
     return legend;
+};
+
+/**
+ * Overrides layout-computed positions with any coordinates previously saved
+ * by the user. Must be called after layoutFunctions and before
+ * associateNonFunctions so that non-functional symbols are placed relative
+ * to the restored positions.
+ */
+export const restoreSavedPositions = (graph: Graph, goals: ClusterGoal[]) => {
+    const positionMap = new Map<string, { x: number; y: number }>();
+    const collect = (goal: ClusterGoal) => {
+        if (goal.GoalType === "Functional" && goal.x !== undefined && goal.y !== undefined) {
+            positionMap.set(generateCellId("Functional", goal.instanceId), { x: goal.x, y: goal.y });
+        }
+        goal.SubGoals.forEach(collect);
+    };
+    goals.forEach(collect);
+
+    if (positionMap.size === 0) return;
+
+    graph.getChildVertices(graph.getDefaultParent()).forEach(cell => {
+        const id = cell.getId();
+        const pos = id ? positionMap.get(id) : undefined;
+        if (pos) {
+            const geo = cell.getGeometry();
+            if (geo) {
+                graph.getDataModel().setGeometry(cell, new Geometry(pos.x, pos.y, geo.width, geo.height));
+            }
+        }
+    });
 };
 
 /**

--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -14,27 +14,27 @@ import {
 } from "@maxgraph/core";
 import '@maxgraph/core/css/common.css';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
-import ErrorModal, { ErrorModalProps } from "../ErrorModal.tsx";
-import { associateNonFunctions, isGoalNameEmpty, layoutFunctions, renderGoals } from './GraphHelpers';
-import { registerCustomShapes } from "./GraphShapes";
+import ErrorModal, {ErrorModalProps} from "../ErrorModal.tsx";
+import {associateNonFunctions, isGoalNameEmpty, layoutFunctions, renderGoals} from './GraphHelpers';
+import {registerCustomShapes} from "./GraphShapes";
 import "./GraphWorker.css";
-import { useFileContext } from "../context/FileProvider.tsx";
-import { useGraph } from "../context/GraphContext";
-import { Cluster, GlobObject, InstanceId } from "../types.ts";
+import {useFileContext} from "../context/FileProvider.tsx";
+import {useGraph} from "../context/GraphContext";
+import {Cluster, GlobObject, InstanceId} from "../types.ts";
 import GraphSidebar from "./GraphSidebar";
 import WarningMessage from "./WarningMessage";
 
-import { VERTEX_FONT } from "../utils/GraphConstants.tsx"
-import { getCellNumericIds } from "../utils/GraphUtils";
-import { removeGoalIdFromTree, updateTextForInstanceId } from "../context/treeDataSlice.ts";
+import {VERTEX_FONT} from "../utils/GraphConstants.tsx"
+import {getCellNumericIds, validateInstanceId} from "../utils/GraphUtils";
+import {removeGoalIdFromTree, updateTextForInstanceId, updatePositionForInstanceId} from "../context/treeDataSlice.ts";
 import ConfirmModal from "../ConfirmModal.tsx";
-import { parseGoalRefId } from "../utils/GraphUtils";
-import { fixEditorPosition, returnFocusToGraph } from "../utils/GraphUtils.tsx";
+import {parseGoalRefId} from "../utils/GraphUtils";
+import {fixEditorPosition, returnFocusToGraph} from "../utils/GraphUtils.tsx";
 
 //Graph id & Side bar id
 const GRAPH_DIV_ID = "graphContainer";
@@ -60,6 +60,8 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
     const { graph, setGraph } = useGraph();
     const treeIdsRef = useRef(treeIds);
     treeIdsRef.current = treeIds;
+    // Guards against dispatching stale positions while renderGraph is rebuilding cells.
+    const isRenderingRef = useRef(false);
 
 
     const hasFunctionalGoal = (cluster: Cluster) => (
@@ -316,6 +318,14 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
                             }
                             if (cellID) {
                                 cellHistory[cellID] = [newWidth, newHeight];
+                            }
+
+                            if (!isRenderingRef.current && cellID?.startsWith("Functional-")) {
+                                const geo = cell.getGeometry();
+                                if (geo !== null) {
+                                    const instanceId = validateInstanceId(cellID.replace("Functional-", ""));
+                                    dispatch(updatePositionForInstanceId({ instanceId, x: geo.x, y: geo.y }));
+                                }
                             }
                         }
                         else if (change.constructor.name == "ValueChange") {

--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -320,6 +320,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
                                 cellHistory[cellID] = [newWidth, newHeight];
                             }
 
+                            // Only persist user-initiated drags; skip events fired during renderGraph.
                             if (!isRenderingRef.current && cellID?.startsWith("Functional-")) {
                                 const geo = cell.getGeometry();
                                 if (geo !== null) {

--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -20,7 +20,7 @@ import Container from "react-bootstrap/Container";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
 import ErrorModal, {ErrorModalProps} from "../ErrorModal.tsx";
-import {associateNonFunctions, isGoalNameEmpty, layoutFunctions, renderGoals} from './GraphHelpers';
+import {associateNonFunctions, isGoalNameEmpty, layoutFunctions, renderGoals, restoreSavedPositions} from './GraphHelpers';
 import {registerCustomShapes} from "./GraphShapes";
 import "./GraphWorker.css";
 import {useFileContext} from "../context/FileProvider.tsx";
@@ -506,6 +506,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
         const qualitiesGlob: GlobObject = {};
         const stakeholdersGlob: GlobObject = {};
 
+        isRenderingRef.current = true;
         resetGraph(
             graph,
             rootGoalWrapper,
@@ -518,6 +519,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
         // Check if the browser is supported
         if (!Client.isBrowserSupported()) {
             error("Browser not supported!", 200, false);
+            isRenderingRef.current = false;
             return;
         }
 
@@ -537,6 +539,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
         );
         rootGoal = rootGoalWrapper.value;
         layoutFunctions(graph, rootGoal);
+        restoreSavedPositions(graph, cluster.ClusterGoals);
 
         // render non-functional goals
         associateNonFunctions(
@@ -549,6 +552,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({ showGraphSectio
             stakeholdersGlob
         );
         graph.getDataModel().endUpdate();
+        isRenderingRef.current = false;
     }, [graph, cluster]);
 
     // First useEffect to set up graph. Only run on mount.

--- a/src/components/context/FileProvider.tsx
+++ b/src/components/context/FileProvider.tsx
@@ -132,6 +132,8 @@ export const convertTreeDataToClusters = (treeData: TreeGoal[]): Cluster => {
             GoalNote: "",
             SubGoals: (item.children) ? item.children.map(convertTreeGoalToClusterGoal) : [],
             GoalColor: item.color,
+            x: item.x,
+            y: item.y,
         };
     };
 

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -256,6 +256,17 @@ export const treeDataSlice = createSlice({
                 node.color = color;
             }
         },
+        updatePositionForInstanceId: (state, action: PayloadAction<{
+            instanceId: InstanceId,
+            x: number,
+            y: number
+        }>) => {
+            const node = findTreeGoalByInstanceId(state.tree, action.payload.instanceId);
+            if (node) {
+                node.x = action.payload.x;
+                node.y = action.payload.y;
+            }
+        },
         reset: (state, action: PayloadAction<{
             tabData: InitialTab[],
             treeData: TreeGoal[]
@@ -279,6 +290,6 @@ export const treeDataSlice = createSlice({
     }
 });
 
-export const {addGoal, addGoalToTab, setTreeData, addGoalToTree, deleteGoalReferenceFromHierarchy, deleteGoalFromGoalList, updateTextForGoalId, reset, removeGoalIdFromTree, updateTextForInstanceId, updateColorForInstanceId} = treeDataSlice.actions;
+export const {addGoal, addGoalToTab, setTreeData, addGoalToTree, deleteGoalReferenceFromHierarchy, deleteGoalFromGoalList, updateTextForGoalId, reset, removeGoalIdFromTree, updateTextForInstanceId, updateColorForInstanceId, updatePositionForInstanceId} = treeDataSlice.actions;
 export const {selectGoalsForLabel} = treeDataSlice.selectors;
 

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -262,7 +262,9 @@ export const treeDataSlice = createSlice({
             y: number
         }>) => {
             const node = findTreeGoalByInstanceId(state.tree, action.payload.instanceId);
-            if (node) {
+            // Equality guard: writing unchanged values would still dirty the Immer draft,
+            // producing a new state.tree ref and retriggering renderGraph indefinitely.
+            if (node && (node.x !== action.payload.x || node.y !== action.payload.y)) {
                 node.x = action.payload.x;
                 node.y = action.payload.y;
             }

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -259,6 +259,9 @@ export const treeDataSlice = createSlice({
                 node.color = color;
             }
         },
+        setVisibilityForLinesBetweenNonFunctionalGoals: (state, action: PayloadAction<boolean>) => {
+            state.showLineBetweenNonFunctionalGoals = action.payload;
+        },
         updatePositionForInstanceId: (state, action: PayloadAction<{
             instanceId: InstanceId,
             x: number,
@@ -295,6 +298,10 @@ export const treeDataSlice = createSlice({
     }
 });
 
-export const {addGoal, addGoalToTab, setTreeData, addGoalToTree, deleteGoalReferenceFromHierarchy, deleteGoalFromGoalList, updateTextForGoalId, reset, removeGoalIdFromTree, updateTextForInstanceId, updateColorForInstanceId, updatePositionForInstanceId} = treeDataSlice.actions;
+export const {
+    addGoal, addGoalToTab, setTreeData, addGoalToTree, deleteGoalReferenceFromHierarchy, deleteGoalFromGoalList,
+    updateTextForGoalId, reset, removeGoalIdFromTree, updateTextForInstanceId, updateColorForInstanceId,
+    setVisibilityForLinesBetweenNonFunctionalGoals, updatePositionForInstanceId
+} = treeDataSlice.actions;
 export const {selectGoalsForLabel} = treeDataSlice.selectors;
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -49,6 +49,8 @@ export type ParsedGoalId = ParsedFunctionalId | ParsedNonFunctionalId;
 
 export interface ClusterGoal extends GoalBase {
     SubGoals: ClusterGoal[]
+    x?: number;
+    y?: number;
 }
 
 export interface GoalList extends Record<GoalType, Goal[]> {
@@ -130,6 +132,8 @@ export type TreeGoal = {
     instanceId: InstanceId;
     children?: TreeGoal[];
     color?: string;
+    x?: number;
+    y?: number;
 };
 
 export const newTreeGoal = (initFields: Pick<TreeGoal, "type"> & Partial<TreeGoal>): TreeGoal => {


### PR DESCRIPTION
Test plan

Start the project with npm run dev
Navigate to the Default Model page and switch to the Graph view
Drag 2–3 functional goals from the sidebar into the graph
Drag them to different positions and note where you placed them
Add a new functional goal from the sidebar
Verify that the previously moved goals remain in their user-arranged positions
Additional checks:

Drag goal A, add a new goal, drag goal B, add another new goal — confirm both A and B keep their positions
Refresh the page (F5), re-enter the Graph view — confirm positions are restored from localStorage
Save the model to a JSON file, reload it — confirm positions survive the round-trip