### PR TITLE
feat(211): Add related links to goals

### DIFF
--- a/src/components/GoalLinkModal.tsx
+++ b/src/components/GoalLinkModal.tsx
@@ -2,25 +2,22 @@ import React, {useState} from "react";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import Modal from "react-bootstrap/Modal";
+import {useFileContext} from "./context/FileProvider";
+import {updateUrlForGoalId} from "./context/treeDataSlice.ts";
 import {TreeGoal} from "./types.ts";
 import {linkTitleForGoal} from "./linkTitleForGoal.ts";
 
 type GoalLinkModalProps = {
-	show: boolean;
-	goal: TreeGoal | null;
-	onHide: () => void;
-	onRemove: () => void;
-	onSave: (url: string) => void;
+	goal: TreeGoal;
+	onClose: () => void;
 };
 
 const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
-	show,
 	goal,
-	onHide,
-	onRemove,
-	onSave,
+	onClose,
 }) => {
-	const [url, setUrl] = useState(goal?.url ?? "");
+	const {dispatch} = useFileContext();
+	const [url, setUrl] = useState(goal.url ?? "");
 	const normalizedUrl = url.trim();
 
 	const isValidUrl = () => {
@@ -38,8 +35,14 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		if (isUrlValid) {
-			onSave(normalizedUrl);
+			dispatch(updateUrlForGoalId({id: goal.id, url: normalizedUrl}));
+			onClose();
 		}
+	};
+
+	const handleRemove = () => {
+		dispatch(updateUrlForGoalId({id: goal.id, url: undefined}));
+		onClose();
 	};
 
 	const handleOpen = () => {
@@ -49,7 +52,7 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 	};
 
 	return (
-		<Modal show={show} onHide={onHide} centered>
+		<Modal show onHide={onClose} centered>
 			<Modal.Header closeButton>
 				<Modal.Title>{linkTitleForGoal(goal)}</Modal.Title>
 			</Modal.Header>
@@ -80,8 +83,8 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 					>
 						Open link
 					</Button>
-					{goal?.url && (
-						<Button type="button" variant="outline-danger" onClick={onRemove}>
+					{goal.url && (
+						<Button type="button" variant="outline-danger" onClick={handleRemove}>
 							Remove
 						</Button>
 					)}

--- a/src/components/GoalLinkModal.tsx
+++ b/src/components/GoalLinkModal.tsx
@@ -54,7 +54,8 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 	return (
 		<Modal show={show} onHide={onHide} centered>
 			<Modal.Header closeButton>
-				<Modal.Title>Related link</Modal.Title>
+				{/* Identify the goal whose link is being edited in the dialog title. */}
+				<Modal.Title>Link for {goal?.content || "this goal"}</Modal.Title>
 			</Modal.Header>
 			<Form onSubmit={handleSubmit}>
 				<Modal.Body>
@@ -71,9 +72,6 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 						<Form.Control.Feedback type="invalid">
 							Enter a valid http:// or https:// URL.
 						</Form.Control.Feedback>
-						<Form.Text muted>
-							Link for {goal?.content || "this goal"}
-						</Form.Text>
 					</Form.Group>
 				</Modal.Body>
 				<Modal.Footer>
@@ -91,9 +89,6 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 							Remove
 						</Button>
 					)}
-					<Button type="button" variant="secondary" onClick={onHide}>
-						Cancel
-					</Button>
 					<Button type="submit" variant="primary" disabled={!isUrlValid}>
 						Save
 					</Button>

--- a/src/components/GoalLinkModal.tsx
+++ b/src/components/GoalLinkModal.tsx
@@ -1,0 +1,106 @@
+import React, {useEffect, useState} from "react";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import Modal from "react-bootstrap/Modal";
+import {TreeGoal} from "./types.ts";
+
+type GoalLinkModalProps = {
+	show: boolean;
+	goal: TreeGoal | null;
+	onHide: () => void;
+	onRemove: () => void;
+	onSave: (url: string) => void;
+};
+
+const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
+	show,
+	goal,
+	onHide,
+	onRemove,
+	onSave,
+}) => {
+	const [url, setUrl] = useState("");
+	const normalizedUrl = url.trim();
+
+	useEffect(() => {
+		setUrl(goal?.url ?? "");
+	}, [goal]);
+
+	const isValidUrl = () => {
+		try {
+			const parsedUrl = new URL(normalizedUrl);
+			return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+		} catch {
+			return false;
+		}
+	};
+
+	const isUrlValid = isValidUrl();
+	const showInvalidUrl = url.length > 0 && !isUrlValid;
+
+	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (isUrlValid) {
+			onSave(normalizedUrl);
+		}
+	};
+
+	const handleOpen = () => {
+		if (isUrlValid) {
+			window.open(normalizedUrl, "_blank", "noopener,noreferrer");
+		}
+	};
+
+	return (
+		<Modal show={show} onHide={onHide} centered>
+			<Modal.Header closeButton>
+				<Modal.Title>Related link</Modal.Title>
+			</Modal.Header>
+			<Form onSubmit={handleSubmit}>
+				<Modal.Body>
+					<Form.Group controlId="goal-related-link">
+						<Form.Label>URL</Form.Label>
+						<Form.Control
+							type="url"
+							value={url}
+							placeholder="Enter an http:// or https:// URL"
+							isInvalid={showInvalidUrl}
+							onChange={(event) => setUrl(event.target.value)}
+							autoFocus
+						/>
+						<Form.Control.Feedback type="invalid">
+							Enter a valid http:// or https:// URL.
+						</Form.Control.Feedback>
+						<Form.Text muted>
+							Link for {goal?.content || "this goal"}
+						</Form.Text>
+					</Form.Group>
+				</Modal.Body>
+				<Modal.Footer>
+					<Button
+						type="button"
+						variant="outline-primary"
+						className="me-auto"
+						disabled={!isUrlValid}
+						onClick={handleOpen}
+					>
+						Open link
+					</Button>
+					{goal?.url && (
+						<Button type="button" variant="outline-danger" onClick={onRemove}>
+							Remove
+						</Button>
+					)}
+					<Button type="button" variant="secondary" onClick={onHide}>
+						Cancel
+					</Button>
+					<Button type="submit" variant="primary" disabled={!isUrlValid}>
+						Save
+					</Button>
+				</Modal.Footer>
+			</Form>
+		</Modal>
+	);
+};
+
+export default GoalLinkModal;

--- a/src/components/GoalLinkModal.tsx
+++ b/src/components/GoalLinkModal.tsx
@@ -1,8 +1,9 @@
-import React, {useEffect, useState} from "react";
+import React, {useState} from "react";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import Modal from "react-bootstrap/Modal";
 import {TreeGoal} from "./types.ts";
+import {linkTitleForGoal} from "./linkTitleForGoal.ts";
 
 type GoalLinkModalProps = {
 	show: boolean;
@@ -19,12 +20,8 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 	onRemove,
 	onSave,
 }) => {
-	const [url, setUrl] = useState("");
+	const [url, setUrl] = useState(goal?.url ?? "");
 	const normalizedUrl = url.trim();
-
-	useEffect(() => {
-		setUrl(goal?.url ?? "");
-	}, [goal]);
 
 	const isValidUrl = () => {
 		try {
@@ -54,8 +51,7 @@ const GoalLinkModal: React.FC<GoalLinkModalProps> = ({
 	return (
 		<Modal show={show} onHide={onHide} centered>
 			<Modal.Header closeButton>
-				{/* Identify the goal whose link is being edited in the dialog title. */}
-				<Modal.Title>Link for {goal?.content || "this goal"}</Modal.Title>
+				<Modal.Title>{linkTitleForGoal(goal)}</Modal.Title>
 			</Modal.Header>
 			<Form onSubmit={handleSubmit}>
 				<Modal.Body>

--- a/src/components/GoalList.tsx
+++ b/src/components/GoalList.tsx
@@ -64,17 +64,13 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
             }
         };
 
-        const handleLinkSave = (url: string) => {
-            if (!linkGoal) return;
-
-            dispatch(updateUrlForGoalId({id: linkGoal.id, url}));
+        const handleLinkSave = (goal: TreeGoal, url: string) => {
+            dispatch(updateUrlForGoalId({id: goal.id, url}));
             setLinkGoal(null);
         };
 
-        const handleLinkRemove = () => {
-            if (!linkGoal) return;
-
-            dispatch(updateUrlForGoalId({id: linkGoal.id}));
+        const handleLinkRemove = (goal: TreeGoal) => {
+            dispatch(updateUrlForGoalId({id: goal.id, url: undefined}));
             setLinkGoal(null);
         };
 
@@ -142,11 +138,13 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
                     </Tab.Content>
                 </Tab.Container>
                 {/* All goal tabs share one link modal. */}
-                <GoalLinkModal show={linkGoal !== null}
-                               goal={linkGoal}
-                               onHide={() => setLinkGoal(null)}
-                               onRemove={handleLinkRemove}
-                               onSave={handleLinkSave}/>
+                {linkGoal && (
+                    <GoalLinkModal show
+                                   goal={linkGoal}
+                                   onHide={() => setLinkGoal(null)}
+                                   onRemove={() => handleLinkRemove(linkGoal)}
+                                   onSave={(url) => handleLinkSave(linkGoal, url)}/>
+                )}
                 <GroupDropBtn />
             </div>
         );

--- a/src/components/GoalList.tsx
+++ b/src/components/GoalList.tsx
@@ -11,8 +11,7 @@ import {BsPlus} from "react-icons/bs";
 import {
     addGoalToTab,
     deleteGoalFromGoalList,
-    selectGoalsForLabel,
-    updateUrlForGoalId
+    selectGoalsForLabel
 } from "./context/treeDataSlice.ts";
 import GoalLinkModal from "./GoalLinkModal.tsx";
 import GoalListTable from "./GoalListTable.tsx";
@@ -62,16 +61,6 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
                 groupSelected.forEach((item: TreeGoal) => dispatch(deleteGoalFromGoalList(item)));
                 setGroupSelected([]);
             }
-        };
-
-        const handleLinkSave = (goal: TreeGoal, url: string) => {
-            dispatch(updateUrlForGoalId({id: goal.id, url}));
-            setLinkGoal(null);
-        };
-
-        const handleLinkRemove = (goal: TreeGoal) => {
-            dispatch(updateUrlForGoalId({id: goal.id, url: undefined}));
-            setLinkGoal(null);
         };
 
         const GroupDropBtn = () => {
@@ -139,11 +128,8 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
                 </Tab.Container>
                 {/* All goal tabs share one link modal. */}
                 {linkGoal && (
-                    <GoalLinkModal show
-                                   goal={linkGoal}
-                                   onHide={() => setLinkGoal(null)}
-                                   onRemove={() => handleLinkRemove(linkGoal)}
-                                   onSave={(url) => handleLinkSave(linkGoal, url)}/>
+                    <GoalLinkModal goal={linkGoal}
+                                   onClose={() => setLinkGoal(null)}/>
                 )}
                 <GroupDropBtn />
             </div>

--- a/src/components/GoalList.tsx
+++ b/src/components/GoalList.tsx
@@ -8,7 +8,13 @@ import {Label, newTreeGoal, TreeGoal} from "./types.ts";
 
 import styles from "./TabButtons.module.css";
 import {BsPlus} from "react-icons/bs";
-import {addGoalToTab, deleteGoalFromGoalList, selectGoalsForLabel} from "./context/treeDataSlice.ts";
+import {
+    addGoalToTab,
+    deleteGoalFromGoalList,
+    selectGoalsForLabel,
+    updateUrlForGoalId
+} from "./context/treeDataSlice.ts";
+import GoalLinkModal from "./GoalLinkModal.tsx";
 import GoalListTable from "./GoalListTable.tsx";
 
 
@@ -24,6 +30,7 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
         const treeData = useFileContext();
         const {dispatch, tabs} = treeData;
         const [activeKey, setActiveKey] = useState<Label>(tabs.keys().next().value ?? "Do");
+        const [linkGoal, setLinkGoal] = useState<TreeGoal | null>(null);
 
         const inputRef = useRef<HTMLInputElement>(null);
 
@@ -55,6 +62,20 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
                 groupSelected.forEach((item: TreeGoal) => dispatch(deleteGoalFromGoalList(item)));
                 setGroupSelected([]);
             }
+        };
+
+        const handleLinkSave = (url: string) => {
+            if (!linkGoal) return;
+
+            dispatch(updateUrlForGoalId({id: linkGoal.id, url}));
+            setLinkGoal(null);
+        };
+
+        const handleLinkRemove = () => {
+            if (!linkGoal) return;
+
+            dispatch(updateUrlForGoalId({id: linkGoal.id}));
+            setLinkGoal(null);
         };
 
         const GroupDropBtn = () => {
@@ -104,6 +125,7 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
                                                groupSelected={groupSelected}
                                                setGroupSelected={setGroupSelected}
                                                handleSynTableTree={handleSynTableTree}
+                                               onLinkClick={setLinkGoal}
                                                inputRef={inputRef}/>
                                 <div className="d-flex justify-content-between align-items-center mt-3">
                                     <Button className="me-2"
@@ -119,6 +141,12 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
                         ))}
                     </Tab.Content>
                 </Tab.Container>
+                {/* All goal tabs share one link modal. */}
+                <GoalLinkModal show={linkGoal !== null}
+                               goal={linkGoal}
+                               onHide={() => setLinkGoal(null)}
+                               onRemove={handleLinkRemove}
+                               onSave={handleLinkSave}/>
                 <GroupDropBtn />
             </div>
         );

--- a/src/components/GoalListTable.tsx
+++ b/src/components/GoalListTable.tsx
@@ -13,7 +13,7 @@ import {
     updateTextForGoalId
 } from "./context/treeDataSlice.ts";
 import {useFileContext} from "./context/FileProvider.tsx";
-import {BsFillTrash3Fill} from "react-icons/bs";
+import {BsFillTrash3Fill, BsLink45Deg} from "react-icons/bs";
 
 const goalDescriptionForLabel = (label: Label): string => {
     const goalNames: Partial<Record<Label, string>> = {
@@ -29,10 +29,11 @@ interface Props {
 	groupSelected: TreeGoal[]
 	setGroupSelected: (groupSelected: TreeGoal[]) => void
 	handleSynTableTree: (treeItem: TreeGoal, editedText: string) => void
+	onLinkClick: (goal: TreeGoal) => void
     inputRef: RefObject<HTMLInputElement>
 }
 
-const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSelected, setGroupSelected, handleSynTableTree, inputRef}) => {
+const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSelected, setGroupSelected, handleSynTableTree, onLinkClick, inputRef}) => {
 	const treeData = useFileContext();
 	const {dispatch, treeIds} = treeData;
 	const [editingGoalId, setEditingGoalId] = useState<number | null>(null);
@@ -236,8 +237,18 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
                                           ref={index === selectGoalsForLabel({treeData}, label).length - 1 ? inputRef : undefined}
                             />
 
+							{/* Open the shared goal link modal for this row. */}
+							<Button
+								type="button"
+								title="Related link"
+								aria-label={`Related link for ${row.content || label}`}
+								onClick={() => onLinkClick(row)}
+							>
+								<BsLink45Deg/>
+							</Button>
+
 							{selectGoalsForLabel({treeData}, label).length > 1 && (
-								<Button onClick={() => handleDeleteRow(row)}>
+								<Button variant="danger" onClick={() => handleDeleteRow(row)}>
 									<BsFillTrash3Fill/>
 								</Button>
 							)}

--- a/src/components/GoalListTable.tsx
+++ b/src/components/GoalListTable.tsx
@@ -237,12 +237,14 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
                                           ref={index === selectGoalsForLabel({treeData}, label).length - 1 ? inputRef : undefined}
                             />
 
-							{/* Keep the link action white with the same subtle border as the input. */}
+							{/* Match the link action background to the adjacent goal input. */}
 							<Button
 								type="button"
 								variant="light"
 								style={{
-									backgroundColor: "white",
+									backgroundColor: isGoalInHierarchy(row)
+										? "white"
+										: "var(--bs-secondary-bg-subtle)",
 									borderColor: "var(--bs-border-color)",
 									borderLeft: "none", // Remove the divider between the input and link action.
 									color: "var(--bs-primary)"

--- a/src/components/GoalListTable.tsx
+++ b/src/components/GoalListTable.tsx
@@ -237,9 +237,16 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
                                           ref={index === selectGoalsForLabel({treeData}, label).length - 1 ? inputRef : undefined}
                             />
 
-							{/* Open the shared goal link modal for this row. */}
+							{/* Keep the link action white with the same subtle border as the input. */}
 							<Button
 								type="button"
+								variant="light"
+								style={{
+									backgroundColor: "white",
+									borderColor: "var(--bs-border-color)",
+									borderLeft: "none", // Remove the divider between the input and link action.
+									color: "var(--bs-primary)"
+								}}
 								title="Related link"
 								aria-label={`Related link for ${row.content || label}`}
 								onClick={() => onLinkClick(row)}
@@ -247,8 +254,9 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
 								<BsLink45Deg/>
 							</Button>
 
+							{/* Match the primary blue background used by the adjacent row action. */}
 							{selectGoalsForLabel({treeData}, label).length > 1 && (
-								<Button variant="danger" onClick={() => handleDeleteRow(row)}>
+								<Button onClick={() => handleDeleteRow(row)}>
 									<BsFillTrash3Fill/>
 								</Button>
 							)}

--- a/src/components/Graphs/GraphHelpers.tsx
+++ b/src/components/Graphs/GraphHelpers.tsx
@@ -57,11 +57,14 @@ const goalLinks = new WeakMap<Cell, string>();
 // continues to work without HTML labels.
 export const getGoalLinkForCell = (cell: Cell): string | undefined => goalLinks.get(cell);
 
-const applyGoalLink = (style: CellStyle, url?: string) => {
-    if (!url) return;
+const applyGoalLink = (style: CellStyle, url?: string): CellStyle => {
+    if (!url) return style;
 
-    style.fontColor = GOAL_LINK_COLOR;
-    style.fontStyle = (style.fontStyle ?? 0) | constants.FONT.UNDERLINE;
+    return {
+        ...style,
+        fontColor: GOAL_LINK_COLOR,
+        fontStyle: (style.fontStyle ?? 0) | constants.FONT.UNDERLINE,
+    };
 };
 
 const registerGoalLink = (cell: Cell, url?: string) => {
@@ -225,9 +228,9 @@ export const renderFunction = (
 
     // Get default style from the stylesheet and clone
     // If not cloned, will affect all nodes instead.
-    const style = {...graph.getStylesheet().getDefaultVertexStyle()};
+    let style = {...graph.getStylesheet().getDefaultVertexStyle()};
     style.fillColor = goalColor;
-    applyGoalLink(style, goal.url);
+    style = applyGoalLink(style, goal.url);
 
     // Make sure to specify what shape we're drawing
     style.shape = config.shape;
@@ -471,7 +474,7 @@ export const renderNonFunction = (
     }
 
     // Clone style to avoid modifying the default
-    const style = {...graph.getStylesheet().getDefaultVertexStyle()};
+    let style = {...graph.getStylesheet().getDefaultVertexStyle()};
     style.shape = shape;
     style.perimeter = "none"
     style.align = "center";
@@ -482,7 +485,7 @@ export const renderNonFunction = (
     // Aggregated symbols can represent several goals, so only create a text
     // link when the rendered label has one unambiguous URL target.
     const goalUrl = descriptions.length === 1 ? descriptions[0].url : undefined;
-    applyGoalLink(style, goalUrl);
+    style = applyGoalLink(style, goalUrl);
 
     // Clone edge style
     const dotted: any = {

--- a/src/components/Graphs/GraphHelpers.tsx
+++ b/src/components/Graphs/GraphHelpers.tsx
@@ -482,9 +482,9 @@ export const renderNonFunction = (
     style.labelPosition = "center";
     style.spacingTop = 0;
 
-    // Aggregated symbols can represent several goals, so only create a text
-    // link when the rendered label has one unambiguous URL target.
-    const goalUrl = descriptions.length === 1 ? descriptions[0].url : undefined;
+    // A non-functional symbol may combine several goals. Only a symbol for a
+    // single goal has one clear link target.
+    const goalUrl = (descriptions.length === 1) ? descriptions[0].url : undefined;
     style = applyGoalLink(style, goalUrl);
 
     // Clone edge style

--- a/src/components/Graphs/GraphHelpers.tsx
+++ b/src/components/Graphs/GraphHelpers.tsx
@@ -2,7 +2,9 @@ import {
     Graph,
     Rectangle,
     Cell,
+    CellStyle,
     Geometry,
+    constants,
 } from "@maxgraph/core";
 import {ClusterGoal, GlobObject, InstanceId} from "../types.ts";
 import {GoalModelLayout} from "./GoalModelLayout";
@@ -47,6 +49,26 @@ const FUNCTIONAL_NONFUNCTIONAL_OFFSET = {
 
 // random string, used to store unassociated non-functions in accumulators
 const ROOT_KEY = "0723y450nv3-2r8mchwouebfioasedfiadfg";
+
+const GOAL_LINK_COLOR = "#0d6efd";
+const goalLinks = new WeakMap<Cell, string>();
+
+// Keep link metadata outside the cell value so existing plain-text editing
+// continues to work without HTML labels.
+export const getGoalLinkForCell = (cell: Cell): string | undefined => goalLinks.get(cell);
+
+const applyGoalLink = (style: CellStyle, url?: string) => {
+    if (!url) return;
+
+    style.fontColor = GOAL_LINK_COLOR;
+    style.fontStyle = (style.fontStyle ?? 0) | constants.FONT.UNDERLINE;
+};
+
+const registerGoalLink = (cell: Cell, url?: string) => {
+    if (url) {
+        goalLinks.set(cell, url);
+    }
+};
 
 /**
  * Recursively renders the goal hierarchy.
@@ -108,13 +130,13 @@ export const renderGoals = (
 
             // accumulate non-functional descriptions into buckets
         } else if (type === SYMBOL_CONFIGS.EMOTIONAL.type) {
-            emotions.push({instanceId, content});
+            emotions.push({instanceId, content, url: goal.url});
         } else if (type === SYMBOL_CONFIGS.NEGATIVE.type) {
-            concerns.push({instanceId, content});
+            concerns.push({instanceId, content, url: goal.url});
         } else if (type === SYMBOL_CONFIGS.QUALITY.type) {
-            qualities.push({instanceId, content});
+            qualities.push({instanceId, content, url: goal.url});
         } else if (type === SYMBOL_CONFIGS.STAKEHOLDER.type) {
-            stakeholders.push({instanceId, content});
+            stakeholders.push({instanceId, content, url: goal.url});
         } else {
             console.log("Logging: goal of unknown type received: " + type);
         }
@@ -205,6 +227,7 @@ export const renderFunction = (
     // If not cloned, will affect all nodes instead.
     const style = {...graph.getStylesheet().getDefaultVertexStyle()};
     style.fillColor = goalColor;
+    applyGoalLink(style, goal.url);
 
     // Make sure to specify what shape we're drawing
     style.shape = config.shape;
@@ -227,6 +250,7 @@ export const renderFunction = (
         height,
         style
     );
+    registerGoalLink(node, goal.url);
     // console.log("goalId:", goal.GoalID, " nodeId:", node.getId(), " value:", node.value);
     if (source) {
         // Insert the edge with specific constraints
@@ -389,7 +413,7 @@ const getConfigByTypeAndDescriptions = (type: string, descriptions: Array<{ inst
 
 // Render a non-functional goal (like emotional, quality, etc.)
 export const renderNonFunction = (
-    descriptions: Array<{ instanceId: InstanceId; content: string; }>,
+    descriptions: Array<{ instanceId: InstanceId; content: string; url?: string; }>,
     graph: Graph,
     source: Cell | null = null,
     type: string = "None",
@@ -455,6 +479,11 @@ export const renderNonFunction = (
     style.labelPosition = "center";
     style.spacingTop = 0;
 
+    // Aggregated symbols can represent several goals, so only create a text
+    // link when the rendered label has one unambiguous URL target.
+    const goalUrl = descriptions.length === 1 ? descriptions[0].url : undefined;
+    applyGoalLink(style, goalUrl);
+
     // Clone edge style
     const dotted: any = {
         ...graph.getStylesheet().getDefaultEdgeStyle(),
@@ -496,6 +525,7 @@ export const renderNonFunction = (
         height,
         style
     );
+    registerGoalLink(node, goalUrl);
     console.log("Nonfunctional-goal-node:", node);
     // Insert an invisible edge
     if (showLineBetweenNonFunctionalGoals) {

--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -20,7 +20,14 @@ import Container from "react-bootstrap/Container";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
 import ErrorModal, {ErrorModalProps} from "../ErrorModal.tsx";
-import {associateNonFunctions, isGoalNameEmpty, layoutFunctions, renderGoals, restoreSavedPositions} from './GraphHelpers';
+import {
+    associateNonFunctions,
+    getGoalLinkForCell,
+    isGoalNameEmpty,
+    layoutFunctions,
+    renderGoals,
+    restoreSavedPositions
+} from './GraphHelpers';
 import {registerCustomShapes} from "./GraphShapes";
 import "./GraphWorker.css";
 import {useFileContext} from "../context/FileProvider.tsx";
@@ -221,6 +228,22 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
     };
 
     const setGraphStyle = (graph: Graph) => {
+        const getDefaultCursorForMouseEvent = graph.getCursorForMouseEvent.bind(graph);
+
+        // MaxGraph normally replaces the label cursor with the movable-node
+        // cursor, so preserve the link cursor while hovering linked text.
+        graph.getCursorForMouseEvent = (mouseEvent) => {
+            const cell = mouseEvent.getCell();
+            const eventTarget = mouseEvent.getSource();
+            const labelNode = cell ? graph.getView().getState(cell)?.text?.node : null;
+
+            if (cell && getGoalLinkForCell(cell) && labelNode?.contains(eventTarget)) {
+                return "pointer";
+            }
+
+            return getDefaultCursorForMouseEvent(mouseEvent);
+        };
+
         // config: permit vertices to be connected by edges
         //graph.setConnectable(true);
         graph.setCellsEditable(true);
@@ -272,6 +295,22 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
 
     const graphListener = useCallback((graph: Graph): (() => void) => {
         const cellHistory: CellHistory = {};
+        const goalLinkClickHandler = (_sender: string, evt: EventObject) => {
+            const cell = evt.getProperty("cell") as Cell | null;
+            if (!cell) return;
+
+            const url = getGoalLinkForCell(cell);
+            const mouseEvent = evt.getProperty("event") as MouseEvent | undefined;
+            const eventTarget = mouseEvent?.target as Node | null;
+            const labelNode = graph.getView().getState(cell)?.text?.node;
+
+            // Only the label acts as a link; the surrounding symbol keeps its
+            // existing selection, drag, resize and edit behaviour.
+            if (!url || !eventTarget || !labelNode?.contains(eventTarget)) return;
+
+            window.open(url, "_blank", "noopener,noreferrer");
+            evt.consume();
+        };
         const changeHandler = (_sender: string, evt: EventObject) => {
                 graph.getDataModel().beginUpdate();
                 evt.consume();
@@ -367,8 +406,12 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
                     graph.refresh();
                 }
             };
+        graph.addListener(InternalEvent.CLICK, goalLinkClickHandler);
         graph.getDataModel().addListener(InternalEvent.CHANGE, changeHandler);
-        return () => graph.getDataModel().removeListener(changeHandler);
+        return () => {
+            graph.removeListener(goalLinkClickHandler);
+            graph.getDataModel().removeListener(changeHandler);
+        };
     }, [dispatch]);
 
     /**
@@ -555,6 +598,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
         );
 
         graph.getDataModel().endUpdate();
+
         isRenderingRef.current = false;
     }, [graph, cluster, showLineBetweenNonFunctionalGoals]);
 

--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -296,7 +296,7 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
     const graphListener = useCallback((graph: Graph): (() => void) => {
         const cellHistory: CellHistory = {};
         const goalLinkClickHandler = (_sender: string, evt: EventObject) => {
-            const cell = evt.getProperty("cell") as Cell | null;
+            const cell = evt.getProperty("cell") as Cell ?? null;
             if (!cell) return;
 
             const url = getGoalLinkForCell(cell);

--- a/src/components/Tree.css
+++ b/src/components/Tree.css
@@ -1,14 +1,17 @@
+.link-icon,
 .delete-icon,
 .edit-icon {
 	visibility: hidden;
 	margin-right: 10px;
 }
 
+.link-icon:hover,
 .delete-icon:hover,
 .edit-icon:hover {
 	cursor: pointer;
 }
 
+.tree-list:hover .link-icon,
 .tree-list:hover .delete-icon,
 .tree-list:hover .edit-icon {
 	visibility: visible;

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -12,10 +12,11 @@ import {
     TreeItemComponentProps,
     TreeItems,
 } from "dnd-kit-sortable-tree";
-import {BsCheckCircle, BsFillTrash3Fill, BsGripVertical, BsPencilSquare, BsXCircle} from "react-icons/bs";
+import {BsCheckCircle, BsFillTrash3Fill, BsGripVertical, BsLink45Deg, BsPencilSquare, BsXCircle} from "react-icons/bs";
 import {InstanceId, Label, TreeGoal, isNonFunctionalGoal} from "../components/types.ts";
 import {useFileContext} from "./context/FileProvider";
 import ConfirmModal from "./ConfirmModal";
+import GoalLinkModal from "./GoalLinkModal";
 import {
     handleContentSave,
     handleGoalBlur,
@@ -24,7 +25,7 @@ import {
     isTextEmpty,
 } from "./utils/GoalHint.tsx";
 import "./Tree.css";
-import {deleteGoalReferenceFromHierarchy, setTreeData} from "./context/treeDataSlice.ts";
+import {deleteGoalReferenceFromHierarchy, setTreeData, updateUrlForGoalId} from "./context/treeDataSlice.ts";
 
 const INDENTATION_WIDTH = 24;
 
@@ -76,6 +77,7 @@ type TreeRowProps = TreeItemComponentProps<SortableTreeGoal> & {
     setEditingItemId: React.Dispatch<React.SetStateAction<InstanceId | null>>;
     setEditedText: React.Dispatch<React.SetStateAction<string>>;
     handleSynTableTree: (treeItem: TreeGoal, editedText: string) => void;
+    onLinkClick: (goal: TreeGoal) => void;
     existingGoalReferenceInstanceId: GoalReference[];
     onDeleteItem: (item: TreeGoal) => void;
 };
@@ -181,6 +183,7 @@ const TreeRow = React.forwardRef<HTMLDivElement, TreeRowProps>(({
     setEditingItemId,
     setEditedText,
     handleSynTableTree,
+    onLinkClick,
     existingGoalReferenceInstanceId,
     onDeleteItem,
     ...props
@@ -359,6 +362,21 @@ const TreeRow = React.forwardRef<HTMLDivElement, TreeRowProps>(({
             </div>
           )}
 
+          {!isEditing && (
+            <div
+              className="link-icon"
+              title="Related link"
+              aria-label={`Related link for ${treeItem.content || treeItem.type}`}
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onLinkClick(treeItem);
+              }}
+            >
+              <BsLink45Deg size={iconSize} />
+            </div>
+          )}
+
           <div
             className="edit-icon"
             onMouseDown={(event) => event.stopPropagation()}
@@ -420,6 +438,7 @@ const Tree: React.FC<TreeProps> = ({
     const [disableOnBlur, setDisableOnBlur] = useState(false);
     const [showDeleteWarning, setShowDeleteWarning] = useState(false);
     const [collapsedIds, setCollapsedIds] = useState<Set<InstanceId>>(new Set());
+    const [linkGoal, setLinkGoal] = useState<TreeGoal | null>(null);
     const deletingItemRef = useRef<TreeGoal | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const {treeData, dispatch} = useFileContext();
@@ -464,6 +483,20 @@ const Tree: React.FC<TreeProps> = ({
       dispatch(setTreeData(stripTreeUiState(items)));
     };
 
+    const handleLinkSave = (url: string) => {
+      if (!linkGoal) return;
+
+      dispatch(updateUrlForGoalId({id: linkGoal.id, url}));
+      setLinkGoal(null);
+    };
+
+    const handleLinkRemove = () => {
+      if (!linkGoal) return;
+
+      dispatch(updateUrlForGoalId({id: linkGoal.id}));
+      setLinkGoal(null);
+    };
+
     const DndTreeItem = React.forwardRef<HTMLDivElement, TreeItemComponentProps<SortableTreeGoal>>((props, ref) => (
         <TreeRow
           {...props}
@@ -476,6 +509,7 @@ const Tree: React.FC<TreeProps> = ({
           setEditingItemId={setEditingItemId}
           setEditedText={setEditedText}
           handleSynTableTree={handleSynTableTree}
+          onLinkClick={setLinkGoal}
           existingGoalReferenceInstanceId={existingGoalReferenceInstanceId}
           onDeleteItem={handleDeleteItem}
         />
@@ -492,6 +526,12 @@ const Tree: React.FC<TreeProps> = ({
             onHide={handleDeleteCancel}
             onConfirm={deleteItem}
           />
+          {/* Reuse the goal link modal for hierarchy rows. */}
+          <GoalLinkModal show={linkGoal !== null}
+                         goal={linkGoal}
+                         onHide={() => setLinkGoal(null)}
+                         onRemove={handleLinkRemove}
+                         onSave={handleLinkSave}/>
 
           <SortableTree
             items={sortableItems}

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -25,7 +25,7 @@ import {
     isTextEmpty,
 } from "./utils/GoalHint.tsx";
 import "./Tree.css";
-import {deleteGoalReferenceFromHierarchy, setTreeData, updateUrlForGoalId} from "./context/treeDataSlice.ts";
+import {deleteGoalReferenceFromHierarchy, setTreeData} from "./context/treeDataSlice.ts";
 
 const INDENTATION_WIDTH = 24;
 
@@ -481,16 +481,6 @@ const Tree: React.FC<TreeProps> = ({
       dispatch(setTreeData(stripTreeUiState(items)));
     };
 
-    const handleLinkSave = (goal: TreeGoal, url: string) => {
-      dispatch(updateUrlForGoalId({id: goal.id, url}));
-      setLinkGoal(null);
-    };
-
-    const handleLinkRemove = (goal: TreeGoal) => {
-      dispatch(updateUrlForGoalId({id: goal.id, url: undefined}));
-      setLinkGoal(null);
-    };
-
     const DndTreeItem = React.forwardRef<HTMLDivElement, TreeItemComponentProps<SortableTreeGoal>>((props, ref) => (
         <TreeRow
           {...props}
@@ -522,11 +512,8 @@ const Tree: React.FC<TreeProps> = ({
           />
           {/* Reuse the goal link modal for hierarchy rows. */}
           {linkGoal && (
-              <GoalLinkModal show
-                             goal={linkGoal}
-                             onHide={() => setLinkGoal(null)}
-                             onRemove={() => handleLinkRemove(linkGoal)}
-                             onSave={(url) => handleLinkSave(linkGoal, url)}/>
+              <GoalLinkModal goal={linkGoal}
+                  onClose={() => setLinkGoal(null)}/>
           )}
 
           <SortableTree

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -363,18 +363,16 @@ const TreeRow = React.forwardRef<HTMLDivElement, TreeRowProps>(({
           )}
 
           {!isEditing && (
-            <div
-              className="link-icon"
-              title="Related link"
-              aria-label={`Related link for ${treeItem.content || treeItem.type}`}
-              onMouseDown={(event) => event.stopPropagation()}
-              onClick={(event) => {
-                event.stopPropagation();
-                onLinkClick(treeItem);
-              }}
-            >
-              <BsLink45Deg size={iconSize} />
-            </div>
+              <div className="link-icon"
+                  title="Related link"
+                  aria-label={`Related link for ${treeItem.content || treeItem.type}`}
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                      event.stopPropagation();
+                      onLinkClick(treeItem);
+                  }}>
+                  <BsLink45Deg size={iconSize} />
+              </div>
           )}
 
           <div
@@ -483,17 +481,13 @@ const Tree: React.FC<TreeProps> = ({
       dispatch(setTreeData(stripTreeUiState(items)));
     };
 
-    const handleLinkSave = (url: string) => {
-      if (!linkGoal) return;
-
-      dispatch(updateUrlForGoalId({id: linkGoal.id, url}));
+    const handleLinkSave = (goal: TreeGoal, url: string) => {
+      dispatch(updateUrlForGoalId({id: goal.id, url}));
       setLinkGoal(null);
     };
 
-    const handleLinkRemove = () => {
-      if (!linkGoal) return;
-
-      dispatch(updateUrlForGoalId({id: linkGoal.id}));
+    const handleLinkRemove = (goal: TreeGoal) => {
+      dispatch(updateUrlForGoalId({id: goal.id, url: undefined}));
       setLinkGoal(null);
     };
 
@@ -527,11 +521,13 @@ const Tree: React.FC<TreeProps> = ({
             onConfirm={deleteItem}
           />
           {/* Reuse the goal link modal for hierarchy rows. */}
-          <GoalLinkModal show={linkGoal !== null}
-                         goal={linkGoal}
-                         onHide={() => setLinkGoal(null)}
-                         onRemove={handleLinkRemove}
-                         onSave={handleLinkSave}/>
+          {linkGoal && (
+              <GoalLinkModal show
+                             goal={linkGoal}
+                             onHide={() => setLinkGoal(null)}
+                             onRemove={() => handleLinkRemove(linkGoal)}
+                             onSave={(url) => handleLinkSave(linkGoal, url)}/>
+          )}
 
           <SortableTree
             items={sortableItems}

--- a/src/components/context/FileProvider.test.tsx
+++ b/src/components/context/FileProvider.test.tsx
@@ -3,7 +3,11 @@
 */
 import {act, renderHook} from '@testing-library/react';
 import {beforeAll, describe, expect, it} from "vitest";
-import FileProvider, {createTreeIdsFromTreeData, useFileContext} from "./FileProvider";
+import FileProvider, {
+    convertTreeDataToClusters,
+    createTreeIdsFromTreeData,
+    useFileContext
+} from "./FileProvider";
 import {newTreeGoal, TreeGoal} from "../types.ts";
 import {enableMapSet} from "immer";
 import {
@@ -186,5 +190,19 @@ describe('#createTreeIdsFromTreeData', () => {
         expect(Object.keys(treeIds)).toEqual(["1", "2"]);
         expect(treeIds[g1.id]).toEqual(["1-0"]);
         expect(treeIds[g2.id]).toEqual(["2-0"]);
+    });
+});
+
+describe('#convertTreeDataToClusters', () => {
+    it('preserves goal URLs used by the graph renderer', () => {
+        const treeGoal = newTreeGoal({
+            type: "Do",
+            id: 10,
+            url: "https://example.com",
+        });
+
+        const cluster = convertTreeDataToClusters([treeGoal]);
+
+        expect(cluster.ClusterGoals[0].url).toBe(treeGoal.url);
     });
 });

--- a/src/components/context/FileProvider.tsx
+++ b/src/components/context/FileProvider.tsx
@@ -133,6 +133,7 @@ export const convertTreeDataToClusters = (treeData: TreeGoal[]): Cluster => {
             GoalContent: item.content,
             GoalNote: "",
             SubGoals: (item.children) ? item.children.map(convertTreeGoalToClusterGoal) : [],
+            url: item.url,
             GoalColor: item.color,
             x: item.x,
             y: item.y,

--- a/src/components/context/treeDataSlice.test.ts
+++ b/src/components/context/treeDataSlice.test.ts
@@ -18,7 +18,8 @@ import {
     selectGoalsForLabel,
     treeDataSlice,
     updateTextForGoalId,
-    updateTextForInstanceId
+    updateTextForInstanceId,
+    updateUrlForGoalId
 } from "./treeDataSlice";
 import {enableMapSet} from "immer";
 import {initialTabs} from "../../data/initialTabs.ts";
@@ -92,6 +93,22 @@ describe('treeDataSlice', () => {
         const state2 = treeDataSlice.reducer(initialState, updateTextForGoalId({id: goal.id, text}));
 
         expect(state2.goals[goal.id].content).toEqual(text);
+    });
+    it('should update and remove the URL for a goal and its tree references', () => {
+        const goal = newTreeGoal({id: 7, type: "Do", content: "example"});
+        const url = "https://example.com";
+
+        let state = treeDataSlice.reducer(initialState, addGoal(goal));
+        state = treeDataSlice.reducer(state, addGoalToTree(goal));
+        state = treeDataSlice.reducer(state, updateUrlForGoalId({id: goal.id, url}));
+
+        expect(state.goals[goal.id].url).toEqual(url);
+        expect(state.tree[0].url).toEqual(url);
+
+        state = treeDataSlice.reducer(state, updateUrlForGoalId({id: goal.id}));
+
+        expect(state.goals[goal.id].url).toBeUndefined();
+        expect(state.tree[0].url).toBeUndefined();
     });
     it('should update text of goal in tree by instanceId (canvas double-click edit)', () => {
         const goal = newTreeGoal({id: 7, type: "Do", content: "example"});

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -120,15 +120,11 @@ const removeAllReferenceFromHierarchy = (
 const updateUrlForGoalReferences = (
     nodes: TreeGoal[],
     goalId: TreeGoal["id"],
-    url?: string,
+    url: string | undefined,
 ) => {
     nodes.forEach((node) => {
         if (node.id === goalId) {
-            if (url) {
-                node.url = url;
-            } else {
-                delete node.url;
-            }
+            node.url = url;
         }
         updateUrlForGoalReferences(node.children ?? [], goalId, url);
     });
@@ -250,16 +246,14 @@ export const treeDataSlice = createSlice({
         },
         updateUrlForGoalId: (state, action: PayloadAction<{
             id: TreeGoal["id"],
-            url?: string
+            url: string | undefined
         }>) => {
             const goal = state.goals[action.payload.id];
-            if (!goal) return;
-
-            if (action.payload.url) {
-                goal.url = action.payload.url;
-            } else {
-                delete goal.url;
+            if (!goal) {
+                throw new Error(`Cannot update URL for missing goal ${action.payload.id}`);
             }
+
+            goal.url = action.payload.url;
 
             // Keep saved hierarchy references consistent with the goal list.
             updateUrlForGoalReferences(state.tree, action.payload.id, action.payload.url);

--- a/src/components/context/treeDataSlice.ts
+++ b/src/components/context/treeDataSlice.ts
@@ -117,6 +117,23 @@ const removeAllReferenceFromHierarchy = (
         }));
 };
 
+const updateUrlForGoalReferences = (
+    nodes: TreeGoal[],
+    goalId: TreeGoal["id"],
+    url?: string,
+) => {
+    nodes.forEach((node) => {
+        if (node.id === goalId) {
+            if (url) {
+                node.url = url;
+            } else {
+                delete node.url;
+            }
+        }
+        updateUrlForGoalReferences(node.children ?? [], goalId, url);
+    });
+};
+
 const generateMaxSuffix = (treeIds: Record<TreeGoal["id"], InstanceId[]>, goalId: TreeGoal["id"]): number => {
     const ids = treeIds[goalId]?.filter((id) => id !== null);  // filter out undefined & null
     if (!ids || ids.length === 0) return 0;
@@ -231,6 +248,22 @@ export const treeDataSlice = createSlice({
                 content: action.payload.text
             };
         },
+        updateUrlForGoalId: (state, action: PayloadAction<{
+            id: TreeGoal["id"],
+            url?: string
+        }>) => {
+            const goal = state.goals[action.payload.id];
+            if (!goal) return;
+
+            if (action.payload.url) {
+                goal.url = action.payload.url;
+            } else {
+                delete goal.url;
+            }
+
+            // Keep saved hierarchy references consistent with the goal list.
+            updateUrlForGoalReferences(state.tree, action.payload.id, action.payload.url);
+        },
         updateTextForInstanceId: (state, action: PayloadAction<{
             instanceId: string,
             text: string
@@ -301,7 +334,6 @@ export const treeDataSlice = createSlice({
 export const {
     addGoal, addGoalToTab, setTreeData, addGoalToTree, deleteGoalReferenceFromHierarchy, deleteGoalFromGoalList,
     updateTextForGoalId, reset, removeGoalIdFromTree, updateTextForInstanceId, updateColorForInstanceId,
-    setVisibilityForLinesBetweenNonFunctionalGoals, updatePositionForInstanceId
+    setVisibilityForLinesBetweenNonFunctionalGoals, updatePositionForInstanceId, updateUrlForGoalId
 } = treeDataSlice.actions;
 export const {selectGoalsForLabel} = treeDataSlice.selectors;
-

--- a/src/components/header/ExportFileButton.tsx
+++ b/src/components/header/ExportFileButton.tsx
@@ -9,6 +9,7 @@ import ErrorModal, {ErrorModalProps} from "../ErrorModal";
 import {useFileContext} from "../context/FileProvider";
 import {useGraph} from "../context/GraphContext";
 import {returnFocusToGraph} from "../utils/GraphUtils";
+import {getGoalLinkForCell} from "../Graphs/GraphHelpers";
 import DropdownButton from "react-bootstrap/DropdownButton";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 
@@ -90,9 +91,31 @@ const ExportFileButton = ({showGraphSection}: { showGraphSection: boolean }) => 
             return;
         }
 
-        // Serialize the SVG element to a string
+        // Add real SVG anchors to a copy so exported links remain clickable
+        // without changing the live maxGraph DOM.
+        const svgForExport = svgElement.cloneNode(true) as SVGSVGElement;
+        const sourceElements = Array.from(svgElement.querySelectorAll("*"));
+        const clonedElements = Array.from(svgForExport.querySelectorAll("*"));
+
+        graph.getChildVertices(graph.getDefaultParent()).forEach(cell => {
+            const url = getGoalLinkForCell(cell);
+            const labelNode = graph.getView().getState(cell)?.text?.node;
+            const labelIndex = labelNode ? sourceElements.indexOf(labelNode) : -1;
+            const clonedLabel = clonedElements[labelIndex];
+
+            if (!url || !clonedLabel?.parentNode) return;
+
+            const link = document.createElementNS("http://www.w3.org/2000/svg", "a");
+            link.setAttribute("href", url);
+            link.setAttribute("target", "_blank");
+            link.setAttribute("rel", "noopener noreferrer");
+            clonedLabel.parentNode.insertBefore(link, clonedLabel);
+            link.appendChild(clonedLabel);
+        });
+
+        // Serialize the linked SVG copy to a string
         const serializer = new XMLSerializer();
-        const svgString = serializer.serializeToString(svgElement);
+        const svgString = serializer.serializeToString(svgForExport);
         try {
             // If chromium browser
             if ('showSaveFilePicker' in self) {

--- a/src/components/linkTitleForGoal.ts
+++ b/src/components/linkTitleForGoal.ts
@@ -1,0 +1,4 @@
+import {TreeGoal} from "./types.ts";
+
+export const linkTitleForGoal = (goal: TreeGoal | null) =>
+	`Link for ${goal?.content || "this goal"}`;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -128,6 +128,7 @@ export const GoalModelProjectSchema = z.object({
 export type TreeGoal = {
     id: number;
     content: string;
+    url?: string;
     type: Label;
     instanceId: InstanceId;
     children?: TreeGoal[];

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -22,7 +22,7 @@ export interface Goal extends GoalBase {
 }
 
 export interface GlobObject {
-    [key: string]: Array<{instanceId: InstanceId; content: string}>;
+    [key: string]: Array<{instanceId: InstanceId; content: string; url?: string}>;
 }
 
 // Common base for all goal reference info
@@ -49,6 +49,7 @@ export type ParsedGoalId = ParsedFunctionalId | ParsedNonFunctionalId;
 
 export interface ClusterGoal extends GoalBase {
     SubGoals: ClusterGoal[]
+    url?: string;
     x?: number;
     y?: number;
 }
@@ -110,6 +111,7 @@ export const GoalListSchema = z.object({
 
 // note recursive types require a bit of extra fiddling
 export const ClusterGoalSchema: z.ZodType<ClusterGoal> = GoalBaseSchema.extend({
+    url: z.string().optional(),
     SubGoals: z.lazy(() => ClusterGoalSchema.array())
 });
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -49,7 +49,7 @@ export type ParsedGoalId = ParsedFunctionalId | ParsedNonFunctionalId;
 
 export interface ClusterGoal extends GoalBase {
     SubGoals: ClusterGoal[]
-    url?: string;
+    url: string | undefined;
     x?: number;
     y?: number;
 }


### PR DESCRIPTION
## Summary

Adds support for associating related web links with goals.

## Changes

- Added a link button to each goal in the goal list.
- Added the same link action to goals in the hierarchy view.
- Added a modal for adding, updating, opening, and removing URLs.
- Restricted links to valid `http://` and `https://` URLs.
- Persisted goal URLs with the existing local goal data.
- Displayed linked goals as blue, underlined text in the rendered model.
- Made rendered goal text clickable without affecting node dragging or editing.
- Preserved clickable links when exporting the model as SVG.


## Screenshot

### Link button
<img width="785" height="111" alt="image" src="https://github.com/user-attachments/assets/b57842a7-2ee0-48f8-aa22-f8343bab1302" />
<img width="844" height="321" alt="image" src="https://github.com/user-attachments/assets/a7ba0055-5113-4002-bf43-c8173c5fa975" />

### Popup window
<img width="488" height="232" alt="image" src="https://github.com/user-attachments/assets/c5f262cf-d72f-4991-9c42-d708136753a3" />

### Render model
<img width="472" height="410" alt="image" src="https://github.com/user-attachments/assets/99a8d8a2-4d23-4670-9848-6638d46684fd" />

