### PR TITLE
Fix image asset paths and improve PNG export quality

### DIFF
--- a/src/components/DetailCarousel.tsx
+++ b/src/components/DetailCarousel.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 
 import Carousel from "react-bootstrap/Carousel";
+import LeonIcon from "/leon.png";
 
 export const DetailCarousel: React.FC = () => (
     <Carousel interval={null}>
         <Carousel.Item>
             <div className="content">
-                <img src="./leon.png"
+                <img src={LeonIcon}
                      alt="leon_icon"
                      style={{height: "100px", width: "auto"}}/>
                 <h1 className="my-4">AMMBER</h1>

--- a/src/components/header/ExportFileButton.tsx
+++ b/src/components/header/ExportFileButton.tsx
@@ -12,6 +12,8 @@ import {returnFocusToGraph} from "../utils/GraphUtils";
 import DropdownButton from "react-bootstrap/DropdownButton";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 
+const PNG_EXPORT_SCALE = 3;
+
 // Add showGraphSection prop to control Export button enablement
 // This ensures Export is only available when user is in "Render Model" interface
 const ExportFileButton = ({showGraphSection}: { showGraphSection: boolean }) => {
@@ -154,18 +156,21 @@ const ExportFileButton = ({showGraphSection}: { showGraphSection: boolean }) => 
 
         // Create a canvas element
         const canvas = document.createElement('canvas');
-        // Set canvas dimensions to match the SVG size
-        canvas.width = svgElement.clientWidth;
-        canvas.height = svgElement.clientHeight;
+        // Render at a higher pixel density for a sharper PNG export
+        canvas.width = Math.round(svgElement.clientWidth * PNG_EXPORT_SCALE);
+        canvas.height = Math.round(svgElement.clientHeight * PNG_EXPORT_SCALE);
 
         const context = canvas.getContext('2d');
         if (!context) {
             console.error('Failed to get canvas context.');
             return;
         }
+        context.scale(PNG_EXPORT_SCALE, PNG_EXPORT_SCALE);
 
         // Use Canvg to render SVG onto the canvas
-        const v = Canvg.fromString(context, svgString);
+        const v = Canvg.fromString(context, svgString, {
+            ignoreDimensions: true
+        });
 
         // Render SVG onto the canvas
         await v.render();

--- a/src/components/utils/GraphConstants.tsx
+++ b/src/components/utils/GraphConstants.tsx
@@ -3,6 +3,12 @@
 
 // --- Default Element Dimensions ---
 import {CellStateStyle} from "@maxgraph/core";
+import BeIcon from "/img/Cloud.png";
+import DoIcon from "/img/Function.png";
+import FeelIcon from "/img/Heart.png";
+import ConcernIcon from "/img/Risk.png";
+import WhoIcon from "/img/Stakeholder.png";
+import LineIcon from "/img/line.svg";
 
 export const LINE_SIZE = 50;             // Line length between nodes
 export const SYMBOL_WIDTH = 145;         // Base width of a symbol node
@@ -39,21 +45,21 @@ export const SYMBOL_CONFIGS: Record<SymbolKey, SymbolConfig> = {
     FUNCTIONAL: {
         type: "Functional",
         shape: "parallelogramShape",
-        imagePath: "img/Function.png",
+        imagePath: DoIcon,
         scale: {width: 1.045, height: 0.8},
         label: "Do",
     },
     EMOTIONAL: {
         type: "Emotional",
         shape: "heartShape",
-        imagePath: "img/Heart.png",
+        imagePath: FeelIcon,
         scale: {width: 0.9, height: 0.96},
         label: "Feel",
     },
     NEGATIVE: {
         type: "Negative",
         shape: "negativeShape",
-        imagePath: "img/Risk.png",
+        imagePath: ConcernIcon,
         scale: {width: 0.9, height: 0.96},
         shapeStyle: {
             fillColor: 'grey',
@@ -63,14 +69,14 @@ export const SYMBOL_CONFIGS: Record<SymbolKey, SymbolConfig> = {
     QUALITY: {
         type: "Quality",
         shape: "cloudShape",
-        imagePath: "img/Cloud.png",
+        imagePath: BeIcon,
         scale: {width: 1, height: 0.8},
         label: "Be",
     },
     STAKEHOLDER: {
         type: "Stakeholder",
         shape: "personShape",
-        imagePath: "img/Stakeholder.png",
+        imagePath: WhoIcon,
         scale: {width: 0.6, height: 1.0},
         shapeStyle: {
             verticalAlign: 'top',
@@ -82,7 +88,7 @@ export const SYMBOL_CONFIGS: Record<SymbolKey, SymbolConfig> = {
     CROWD: {
         type: "Crowd",
         shape: "crowdShape",
-        imagePath: "img/Stakeholder.png",
+        imagePath: WhoIcon,
         scale: {width: 0.7, height: 1.0},
         shapeStyle: {
             verticalAlign: 'top',
@@ -95,4 +101,4 @@ export const SYMBOL_CONFIGS: Record<SymbolKey, SymbolConfig> = {
 
 // --- Additional Assets ---
 // Path to the default line image used in the diagram.
-export const LINE_IMAGE_PATH = "img/line.svg";
+export const LINE_IMAGE_PATH = LineIcon;


### PR DESCRIPTION
## Summary

This PR fixes two issues related to image loading and PNG export quality.

### 1. Fix image loading

Some icons were referenced using inconsistent hard-coded relative paths, such as `img/...` and `./leon.png`. When the application was deployed under the `/mm-local-editor/` base path, these references could resolve to incorrect locations and result in `404` errors.

The image references have been replaced with Vite static imports. The generated asset URLs are now used consistently in both MaxGraph's `imagePath` configuration and React `<img>` elements, ensuring that the icons load correctly in both development and production environments.

### 2. Improve exported PNG quality

Exported PNG files appeared blurry because the graph was rendered using the SVG's on-screen resolution.

The export process now creates a canvas at three times the original dimensions and scales the drawing context accordingly. 