### PR TITLE
feat: add persistent spellcheck even after exiting goal

### DIFF
--- a/src/components/GoalList.tsx
+++ b/src/components/GoalList.tsx
@@ -25,7 +25,7 @@ const GoalList = React.forwardRef<HTMLDivElement, GoalListProps>(({setDraggedIte
         const {dispatch, tabs} = treeData;
         const [activeKey, setActiveKey] = useState<Label>(tabs.keys().next().value ?? "Do");
 
-        const inputRef = useRef<HTMLInputElement>(null);
+        const inputRef = useRef<HTMLDivElement>(null);
 
         // Function to handle selecting a tab
         const handleSelect = (selectedKey: Label) => {

--- a/src/components/GoalListTable.tsx
+++ b/src/components/GoalListTable.tsx
@@ -14,6 +14,7 @@ import {
 } from "./context/treeDataSlice.ts";
 import {useFileContext} from "./context/FileProvider.tsx";
 import {BsFillTrash3Fill} from "react-icons/bs";
+import SpellcheckGoalInput from "./SpellcheckGoalInput.tsx";
 
 const goalDescriptionForLabel = (label: Label): string => {
     const goalNames: Partial<Record<Label, string>> = {
@@ -29,7 +30,7 @@ interface Props {
 	groupSelected: TreeGoal[]
 	setGroupSelected: (groupSelected: TreeGoal[]) => void
 	handleSynTableTree: (treeItem: TreeGoal, editedText: string) => void
-    inputRef: RefObject<HTMLInputElement>
+    inputRef: RefObject<HTMLDivElement>
 }
 
 const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSelected, setGroupSelected, handleSynTableTree, inputRef}) => {
@@ -41,7 +42,7 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
 
 	// add new row
 	const handleKeyPress = (
-		e: React.KeyboardEvent<HTMLInputElement>,
+		e: React.KeyboardEvent<HTMLElement>,
 		label: Label
 	) => {
 		if (e.key === "Enter") {
@@ -56,7 +57,7 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
 	};
 
 	// Handle key press with GoalHint functions
-	const handleTableKeyPress = (e: React.KeyboardEvent<HTMLInputElement>, row: TreeGoal, label: Label) => {
+	const handleTableKeyPress = (e: React.KeyboardEvent<HTMLElement>, row: TreeGoal, label: Label) => {
 
 		// If we're editing this specific goal
 		if (editingGoalId === row.id && !newRowAllowed) {
@@ -199,7 +200,7 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
 			</thead>
 			<tbody>
 			{goals.map((row, index) => (
-				<tr key={`${label}-${index}`}>
+				<tr key={row.id}>
 					<td className="align-middle">
 						<Form.Check type="checkbox"
 									onChange={() => handleCheckboxToggle(row)}
@@ -208,13 +209,15 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
 					</td>
 					<td>
 						<InputGroup>
-                            <Form.Control onDragStart={() => handleDragStart(row)}
+                            <SpellcheckGoalInput
+                                          onDragStart={() => handleDragStart(row)}
                                           draggable={isGoalDraggable(row)} // Only draggable if not empty
-                                          type="text"
                                           value={editingGoalId === row.id ? editedText : row.content} // Show edited text when editing
-                                          onChange={(e) => {
+                                          aria-label={`${goalDescriptionForLabel(label)} ${index + 1}`}
+                                          aria-invalid={editingGoalId === row.id && isTextEmpty(editedText)}
+                                          onChange={(value) => {
                                               if (editingGoalId === row.id) {
-                                                  setEditedText(e.target.value); // Allow free typing
+                                                  setEditedText(value); // Allow free typing
                                               }
                                           }}
                                           onFocus={() => {
@@ -225,13 +228,12 @@ const GoalListTable: React.FC<Props> = ({label, goals, setDraggedItem, groupSele
                                               }
                                           }}
                                           placeholder={`Enter ${label}...`}
-                                          spellCheck
                                           className={`
 											  ${isEmptyGoal(row) ? "text-muted" : ""}
 											  ${editingGoalId === row.id && isTextEmpty(editedText) ? "is-invalid" : ""}
 											  ${isGoalInHierarchy(row) ? "" : "bg-secondary-subtle"}
 										  `}
-                                          onKeyDown={(e) => handleTableKeyPress(e as React.KeyboardEvent<HTMLInputElement>, row, label)}
+                                          onKeyDown={(e) => handleTableKeyPress(e, row, label)}
                                           onBlur={() => handleTableBlur(row)}
                                           ref={index === selectGoalsForLabel({treeData}, label).length - 1 ? inputRef : undefined}
                             />

--- a/src/components/SpellcheckGoalInput.css
+++ b/src/components/SpellcheckGoalInput.css
@@ -1,0 +1,25 @@
+.spellcheck-goal-input {
+    min-width: 0;
+    min-height: calc(1.5em + 0.75rem + 2px);
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.spellcheck-goal-input:empty::before {
+    color: var(--bs-secondary-color);
+    content: attr(data-placeholder);
+    pointer-events: none;
+}
+
+.spellcheck-goal-input::spelling-error {
+    text-decoration-color: #d93025;
+    text-decoration-line: underline;
+    text-decoration-skip-ink: none;
+    text-decoration-style: wavy;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+}
+
+.spellcheck-goal-input:focus {
+    cursor: text;
+}

--- a/src/components/SpellcheckGoalInput.test.tsx
+++ b/src/components/SpellcheckGoalInput.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, {useState} from "react";
+import {fireEvent, render, screen} from "@testing-library/react";
+import {describe, expect, it, vi} from "vitest";
+
+import SpellcheckGoalInput from "./SpellcheckGoalInput.tsx";
+
+const TestEditor = () => {
+    const [, setEditingId] = useState<number | null>(null);
+    const [values, setValues] = useState(["A mispeled goal", "Another goal"]);
+
+    return values.map((value, index) => (
+        <SpellcheckGoalInput
+            key={index}
+            value={value}
+            placeholder="Enter goal..."
+            aria-label={`Goal ${index + 1}`}
+            onBlur={() => setEditingId(null)}
+            onChange={(nextValue) => {
+                setValues((currentValues) => currentValues.map(
+                    (currentValue, valueIndex) => valueIndex === index ? nextValue : currentValue,
+                ));
+            }}
+            onDragStart={() => undefined}
+            onFocus={() => setEditingId(index)}
+            onKeyDown={() => undefined}
+        />
+    ));
+};
+
+describe("SpellcheckGoalInput", () => {
+    it("keeps the same spellchecked editing host when focus moves between goals", () => {
+        render(<TestEditor />);
+
+        const firstGoal = screen.getByRole("textbox", {name: "Goal 1"});
+        const secondGoal = screen.getByRole("textbox", {name: "Goal 2"});
+
+        expect(firstGoal.getAttribute("spellcheck")).toBe("true");
+        expect(firstGoal.getAttribute("contenteditable")).toBe("plaintext-only");
+
+        fireEvent.focus(firstGoal);
+        firstGoal.textContent = "A persistant mispelling";
+        fireEvent.input(firstGoal);
+        fireEvent.blur(firstGoal);
+        fireEvent.focus(secondGoal);
+
+        expect(screen.getByRole("textbox", {name: "Goal 1"})).toBe(firstGoal);
+        expect(firstGoal.textContent).toBe("A persistant mispelling");
+    });
+
+    it("prevents Enter from inserting a line break", () => {
+        const onKeyDown = vi.fn();
+
+        render(
+            <SpellcheckGoalInput
+                value="Goal"
+                placeholder="Enter goal..."
+                aria-label="Goal"
+                onBlur={() => undefined}
+                onChange={() => undefined}
+                onDragStart={() => undefined}
+                onFocus={() => undefined}
+                onKeyDown={onKeyDown}
+            />,
+        );
+
+        const goal = screen.getByRole("textbox", {name: "Goal"});
+        const eventAccepted = fireEvent.keyDown(goal, {key: "Enter"});
+
+        expect(eventAccepted).toBe(false);
+        expect(onKeyDown).toHaveBeenCalledOnce();
+    });
+});

--- a/src/components/SpellcheckGoalInput.tsx
+++ b/src/components/SpellcheckGoalInput.tsx
@@ -1,0 +1,91 @@
+import React, {useLayoutEffect, useRef} from "react";
+
+import "./SpellcheckGoalInput.css";
+
+type SpellcheckGoalInputProps = {
+    value: string;
+    placeholder: string;
+    className?: string;
+    draggable?: boolean;
+    "aria-label": string;
+    "aria-invalid"?: boolean;
+    onBlur: () => void;
+    onChange: (value: string) => void;
+    onDragStart: () => void;
+    onFocus: () => void;
+    onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+};
+
+const setRef = (
+    ref: React.ForwardedRef<HTMLDivElement>,
+    element: HTMLDivElement | null,
+) => {
+    if (typeof ref === "function") {
+        ref(element);
+    } else if (ref) {
+        ref.current = element;
+    }
+};
+
+/**
+ * A stable editing host allows the browser to retain its spelling annotations
+ * when focus moves to another goal. React only writes to the DOM when the
+ * requested value actually differs from the visible text.
+ */
+const SpellcheckGoalInput = React.forwardRef<HTMLDivElement, SpellcheckGoalInputProps>(({
+    value,
+    placeholder,
+    className = "",
+    draggable = false,
+    "aria-label": ariaLabel,
+    "aria-invalid": ariaInvalid,
+    onBlur,
+    onChange,
+    onDragStart,
+    onFocus,
+    onKeyDown,
+}, forwardedRef) => {
+    const editorRef = useRef<HTMLDivElement | null>(null);
+
+    useLayoutEffect(() => {
+        const editor = editorRef.current;
+
+        if (editor && editor.textContent !== value) {
+            editor.textContent = value;
+        }
+    }, [value]);
+
+    return (
+        <div
+            ref={(element) => {
+                editorRef.current = element;
+                setRef(forwardedRef, element);
+            }}
+            role="textbox"
+            aria-label={ariaLabel}
+            aria-invalid={ariaInvalid}
+            aria-multiline="false"
+            className={`form-control spellcheck-goal-input ${className}`}
+            contentEditable="plaintext-only"
+            suppressContentEditableWarning
+            spellCheck
+            data-placeholder={placeholder}
+            draggable={draggable}
+            onDragStart={onDragStart}
+            onFocus={onFocus}
+            onInput={(event) => onChange(event.currentTarget.textContent ?? "")}
+            onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                    event.preventDefault();
+                }
+
+                onKeyDown(event);
+            }}
+            onBlur={onBlur}
+        />
+    );
+});
+
+SpellcheckGoalInput.displayName = "SpellcheckGoalInput";
+
+export default SpellcheckGoalInput;

--- a/src/components/utils/GoalHint.tsx
+++ b/src/components/utils/GoalHint.tsx
@@ -36,12 +36,12 @@ export function handleContentSave(
 
 // Handle key press events for goal editing
 export function handleGoalKeyPress(
-  event: React.KeyboardEvent<HTMLInputElement>,
+  event: React.KeyboardEvent<HTMLElement>,
   originalContent: string,
   currentContent: string,
   onSave: (content: string) => void,
   onCancel: () => void,
-  onOtherKey?: (event: React.KeyboardEvent<HTMLInputElement>) => void
+  onOtherKey?: (event: React.KeyboardEvent<HTMLElement>) => void
 ): void {
   if (event.key === "Enter") {
     // call input Onsave Function


### PR DESCRIPTION
## Summary

Improves browser-based spellchecking to goal inputs so that it preserves the spelling error underline even when users move between goals.

## Changes

- Added a reusable spellchecked goal input component.
- Preserved spelling error underline after a goal loses focus.
- Added a cleaner, modern red spelling error underline.
- Prevented Enter from inserting line breaks into goal names.
- Added stable goal row identifiers to avoid unnecessary input replacement.
- Added tests for focus changes and single-line input behavior.

## Testing

- [x] All 62 automated tests pass.
- [x] Production build completes successfully.
- [x] Changed TypeScript files pass linting.
- [x] Confirmed misspelled words remain underlined after editing another goal.
- [x] Confirmed browser spelling suggestions and corrections still work.

## Screenshots

https://github.com/user-attachments/assets/e4cbfb8a-af79-4b7b-ac20-83ce10aaa3b2

## Notes

- Spelling detection and suggestions use the browser’s configured dictionary.
- The timing of native spelling detection is controlled by the browser.