### PR TITLE
fix: allow for free movement again on canvas by dragging

### DIFF
--- a/src/components/Graphs/GraphWorker.css
+++ b/src/components/Graphs/GraphWorker.css
@@ -17,7 +17,11 @@
   height: 100%;
   /* background: url("/img/grid.gif"); */
   background-color: white;
-  cursor: default;
+  cursor: grab;
+}
+
+#graphContainer:active {
+  cursor: grabbing;
 }
 
 .row {

--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -9,6 +9,7 @@ import {
     Graph,
     InternalEvent,
     KeyHandler,
+    PanningHandler,
     RubberBandHandler,
     UndoManager,
 } from "@maxgraph/core";
@@ -225,6 +226,12 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
         //graph.setConnectable(true);
         graph.setCellsEditable(true);
         graph.setPanning(true);
+        const panningHandler = graph.getPlugin<PanningHandler>(PanningHandler.pluginId);
+        if (panningHandler) {
+            // Pan with the primary mouse button only when the pointer is over
+            // empty canvas space, leaving goal dragging and resizing unchanged.
+            panningHandler.useLeftButtonForPanning = true;
+        }
         graph.setCellsResizable(true);
         graph.setCellsMovable(true); // Allow cells to be moved
         graph.setCellsSelectable(true); // Allow cells to be selected

--- a/src/components/UsageInfo/GraphUsageInfo.tsx
+++ b/src/components/UsageInfo/GraphUsageInfo.tsx
@@ -21,6 +21,8 @@ export const GraphUsageInfo = () => {
             <br />
             <strong>Model Panel:</strong>
             <br />
+            • Drag the canvas to move around
+            <br />
             • Select and drag a goal to adjust its position on the graph
             <br />
             • Drag elements from the right toolbar onto the graph to add a goal


### PR DESCRIPTION
## Summary
Adds intuitive canvas panning to the model editor.

## Changes
- Enabled left-click dragging on empty canvas space.
- Added grab/grabbing cursor for user feedback
- Updated the model hint instructions.

## Testing
- [X] Production build passes.
- [X] Existing canvas interactions remain unchanged.

## Screenshots

https://github.com/user-attachments/assets/f4cf6ba6-2c51-4a3e-afde-a8297f835ac6

## Notes
Dragging goals still work as intended, only dragging on the canvas/background pans the canvas.