### PR TITLE
Fix fuzzy text during font resizing (#299)

### DIFF
--- a/cypress/e2e/graph-font-size.cy.ts
+++ b/cypress/e2e/graph-font-size.cy.ts
@@ -1,0 +1,94 @@
+describe('Graph Font Size UI Tests', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.contains('Create Model').click();
+    cy.contains('Arrange Hierarchy / Render Model').click();
+    cy.get('[data-cy="graph-canvas"]').should('be.visible');
+  });
+
+  it('should not display duplicate text when font size changes during editing', () => {
+    cy.get('#graphContainer text').contains('Feel').then(($text) => {
+      cy.wrap(parseFloat(getComputedStyle($text[0]).fontSize)).as('initialFontSize');
+    });
+    cy.get('#graphContainer').contains('Feel').dblclick({force: true});
+    cy.get('.mxCellEditor').should('be.visible');
+
+    cy.contains('Font size').click();
+    cy.contains('Font size').parent().find('input[type="number"]')
+      .type('{selectall}24')
+      .should('have.value', '24');
+
+    cy.get('.mxCellEditor').should('be.visible');
+    cy.get('#graphContainer text').contains('Feel').should('not.be.visible');
+    cy.get('.mxCellEditor').should('have.css', 'font-size', '24px');
+
+    cy.contains('Font size').parent().find('input[type="number"]')
+      .type('{selectall}25')
+      .should('have.value', '25');
+    cy.get('.mxCellEditor').should('have.css', 'font-size', '25px');
+
+    cy.get('.mxCellEditor').type('{esc}');
+    cy.get('.mxCellEditor').should('not.exist');
+    cy.get('@initialFontSize').then((initialFontSize) => {
+      cy.get('#graphContainer text').contains('Feel')
+        .should('be.visible')
+        .and(($text) => {
+          const updatedFontSize = parseFloat(getComputedStyle($text[0]).fontSize);
+          expect(updatedFontSize).to.be.closeTo(Number(initialFontSize) * 25 / 16, 0.1);
+        });
+    });
+  });
+
+  it('should preserve a functional goal shape when font size changes', () => {
+    cy.get('#graphContainer text').contains('Do3').then(($text) => {
+      cy.wrap(parseFloat(getComputedStyle($text[0]).fontSize)).as('initialFunctionalFontSize');
+    });
+    cy.get('#graphContainer text').contains('Do3').click({force: true});
+    cy.get('#graphContainer path').then(($paths) => {
+      const shapePathData = Array.from($paths)
+        .filter((path) => path.getAttribute('fill') !== 'none')
+        .map((path) => path.getAttribute('d'));
+      cy.wrap(shapePathData).as('shapePathData');
+    });
+
+    cy.contains('Font size').click();
+    cy.contains('Font size').parent().find('input[type="number"]')
+      .type('{selectall}17')
+      .should('have.value', '17');
+
+    cy.get('@shapePathData').then((shapePathData) => {
+      cy.get('#graphContainer path').then(($paths) => {
+        const updatedShapePathData = Array.from($paths)
+          .filter((path) => path.getAttribute('fill') !== 'none')
+          .map((path) => path.getAttribute('d'));
+        expect(updatedShapePathData).to.deep.equal(shapePathData);
+      });
+    });
+    cy.get('@initialFunctionalFontSize').then((initialFontSize) => {
+      cy.get('#graphContainer text').contains('Do3').should(($text) => {
+        const updatedFontSize = parseFloat(getComputedStyle($text[0]).fontSize);
+        expect(updatedFontSize).to.be.closeTo(Number(initialFontSize) * 17 / 16, 0.1);
+      });
+    });
+  });
+
+  it('should preserve dotted connections when font size changes', () => {
+    cy.get('#graphContainer path[stroke-dasharray]').then(($paths) => {
+      const pathData = Array.from($paths).map((path) => path.getAttribute('d'));
+      cy.wrap(pathData).as('dottedPathData');
+    });
+
+    cy.get('#graphContainer text').contains('Feel').dblclick({force: true});
+    cy.contains('Font size').click();
+    cy.contains('Font size').parent().find('input[type="number"]')
+      .type('{selectall}24')
+      .should('have.value', '24');
+
+    cy.get('@dottedPathData').then((pathData) => {
+      cy.get('#graphContainer path[stroke-dasharray]').then(($paths) => {
+        const updatedPathData = Array.from($paths).map((path) => path.getAttribute('d'));
+        expect(updatedPathData).to.deep.equal(pathData);
+      });
+    });
+  });
+});

--- a/src/components/Graphs/GraphShapes.tsx
+++ b/src/components/Graphs/GraphShapes.tsx
@@ -12,7 +12,6 @@ import {
   Point,
   utils,
   CellRenderer,
-  Shape,
 } from "@maxgraph/core";
 
 import {
@@ -48,6 +47,11 @@ class ParallelogramShape extends ActorShape {
 
   isRoundable(): boolean {
     return true;
+  }
+
+  resetStyles(): void {
+    super.resetStyles();
+    this.startSize = 0.12;
   }
 
   /**

--- a/src/components/Graphs/GraphWorker.tsx
+++ b/src/components/Graphs/GraphWorker.tsx
@@ -273,10 +273,13 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
     const graphListener = useCallback((graph: Graph): (() => void) => {
         const cellHistory: CellHistory = {};
         const changeHandler = (_sender: string, evt: EventObject) => {
+                const changes = evt.getProperty("edit").changes;
+                const hasNonStyleChanges = changes.some(
+                    (change: {constructor: {name: string}}) => change.constructor.name != "StyleChange"
+                );
                 graph.getDataModel().beginUpdate();
                 evt.consume();
                 try {
-                    const changes = evt.getProperty("edit").changes;
                     for (let i = 0; i < changes.length; i++) {
                         const change = changes[i];
                         if (change.constructor.name == "GeometryChange") {
@@ -364,7 +367,10 @@ const GraphWorker: React.FC<{ showGraphSection?: boolean }> = ({showGraphSection
                     }
                 } finally {
                     graph.getDataModel().endUpdate();
-                    graph.refresh();
+                    // Style changes are already redrawn by maxGraph and must retain the hidden label while editing.
+                    if (hasNonStyleChanges) {
+                        graph.refresh();
+                    }
                 }
             };
         graph.getDataModel().addListener(InternalEvent.CHANGE, changeHandler);

--- a/src/components/Graphs/ScaleTextButton.tsx
+++ b/src/components/Graphs/ScaleTextButton.tsx
@@ -1,5 +1,6 @@
 import {useState, useEffect} from "react";
 import FormControl from "react-bootstrap/FormControl";
+import {CellEditorHandler} from "@maxgraph/core";
 import {useGraph} from "../context/GraphContext";
 
 const ScaleTextButton = () => {
@@ -47,16 +48,13 @@ const ScaleTextButton = () => {
         if (!graph || newFontSize < 8 || newFontSize > 40) return;
 
         const cells = graph.getSelectionCells();
-        graph.getDataModel().beginUpdate();
-        try {
-            cells.forEach((cell) => {
-                const style = graph.getCellStyle(cell);
-                style.fontSize = newFontSize;
-                graph.getDataModel().setStyle(cell, style);
-            });
-        } finally {
-            graph.getDataModel().endUpdate();
-            graph.refresh();
+        graph.setCellStyles("fontSize", newFontSize, cells);
+
+        const cellEditor = graph.getPlugin<CellEditorHandler>("CellEditorHandler");
+        const editorElement = graph.container.querySelector<HTMLElement>(".mxCellEditor");
+        if (cells.length > 0 && graph.isEditing() && editorElement) {
+            editorElement.style.fontSize = `${newFontSize}px`;
+            cellEditor.resize();
         }
     };
 


### PR DESCRIPTION
Closes #299

## Summary

- Synchronise the inline text editor with font size changes to prevent duplicated or fuzzy text.
- Preserve custom shape rendering when changing the font size.
- Prevent dotted connection lines from becoming partially hidden after style updates.
- Add Cypress regression tests for font size changes.

## Testing

- Ran `npm run build` successfully.
- Ran Cypress tests successfully in Electron.
- Manually tested font resizing on the heart and parallelogram shapes.
- Confirmed that text updates immediately and custom shapes and dotted lines remain visible.