### PR TITLE
Fix: prevent duplicate nested goals

### DIFF
--- a/src/components/SectionPanel.tsx
+++ b/src/components/SectionPanel.tsx
@@ -57,8 +57,8 @@ const SectionPanel: React.FC<SectionPanelProps> = ({
   const [parentWidth, setParentWidth] = useState(0);
 
   const [draggedItem, setDraggedItem] = useState<TreeGoal | null>(null);
-  // Simply store ids of all items in the tree for fast check instead of recursive search
-    const {dispatch, tree} = useFileContext();
+  // Use the flat instance index to check all hierarchy levels without recursive search.
+    const {dispatch, treeIds} = useFileContext();
 
   const [groupSelected, setGroupSelected] = useState<TreeGoal[]>([]);
 
@@ -143,8 +143,7 @@ const SectionPanel: React.FC<SectionPanelProps> = ({
       }
 
       if (draggedItem && draggedItem.content) {
-            // the first hierachy does not contain the dragged item
-            if (!tree.map((item) => item.id).includes(draggedItem.id)) {
+            if (!treeIds[draggedItem.id]?.length) {
               dispatch(addGoalToTree(draggedItem));
           } else {
               setExistingItemIds([...existingItemIds, draggedItem.id]);
@@ -157,12 +156,9 @@ const SectionPanel: React.FC<SectionPanelProps> = ({
   // Add selected items where they are not in the tree to the tree and reset selected items, uncheck the checkboxes
   const handleDropGroupSelected = () => {
     
-    // Filter groupSelected to get only objects whose IDs are not in treeData
+    // Filter out goals that already have an instance at any hierarchy level.
     const newItemsToAdd = groupSelected.filter(
-            // current hierachy
-            (item) => !tree.some(
-                ref => ref.id === item.id
-            )
+            (item) => !treeIds[item.id]?.length
     );
 
     // If all items are in the tree, then show the warning


### PR DESCRIPTION
## Summary

- Use `treeIds` instead of scanning only top-level goals.
- Prevent nested goals from being added again.
- Apply the same duplicate check to single and group additions.